### PR TITLE
Initialize crypto examples

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 
 project(xtt
-        VERSION "0.4.3"
+        VERSION "0.4.4"
         )
 set(PROJECT_VERSION_PACKAGE_REVISION 1)
 

--- a/examples/xtt_client.c
+++ b/examples/xtt_client.c
@@ -36,10 +36,10 @@ unsigned char tcti_context_buffer_g[128];
 #endif
 
 uint32_t key_handle_g = 0x81800000;
-uint32_t gpk_handle_g = 0x1400000;
-uint32_t cred_handle_g = 0x1400001;
-uint32_t root_id_handle_g = 0x1400003;
-uint32_t root_pubkey_handle_g = 0x1400004;
+uint32_t gpk_handle_g = 0x1410000;
+uint32_t cred_handle_g = 0x1410001;
+uint32_t root_id_handle_g = 0x1410003;
+uint32_t root_pubkey_handle_g = 0x1410004;
 const char *tpm_hostname_g = "localhost";
 const char *tpm_port_g = "2321";
 const char *tpm_password = NULL;


### PR DESCRIPTION
The examples weren't initializing the `crypto` sub system (i.e. libsodium).