### PR TITLE
Initialize crypto examples

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 
 project(xtt
-        VERSION "0.4.4"
+        VERSION "0.4.5"
         )
 set(PROJECT_VERSION_PACKAGE_REVISION 1)
 

--- a/examples/xtt_client.c
+++ b/examples/xtt_client.c
@@ -100,6 +100,12 @@ int report_results(xtt_identity_type *requested_client_id,
 
 int main(int argc, char *argv[])
 {
+    int init_ret = xtt_crypto_initialize_crypto();
+    if (0 != init_ret) {
+        fprintf(stderr, "Error initializing cryptography library: %d\n", init_ret);
+        return 1;
+    }
+
     xtt_return_code_type rc = XTT_RETURN_SUCCESS;
     int init_daa_ret = -1;
     int socket = -1;

--- a/examples/xtt_server.c
+++ b/examples/xtt_server.c
@@ -76,6 +76,13 @@ void report_results(struct xtt_server_handshake_context *ctx);
 
 int main(int argc, char *argv[])
 {
+    // 0) Initialize crypto primitives library
+    int init_ret = xtt_crypto_initialize_crypto();
+    if (0 != init_ret) {
+        fprintf(stderr, "Error initializing cryptography library: %d\n", init_ret);
+        return 1;
+    }
+
     // 0) Parse the command line args
     unsigned short server_port;
     parse_cmd_args(argc, argv, &server_port);


### PR DESCRIPTION
The examples weren't initializing the underlying crypto library (i.e. libsodium).