### PR TITLE
Extract private key for Ed25519

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 
 project(xtt
-        VERSION "0.5.0"
+        VERSION "0.5.1"
         )
 
 set(XTT_VERSION ${PROJECT_VERSION})

--- a/include/xtt/crypto_wrapper.h
+++ b/include/xtt/crypto_wrapper.h
@@ -67,6 +67,9 @@ int xtt_crypto_prf_blake2b(unsigned char* out,
 int xtt_crypto_create_ed25519_key_pair(xtt_ed25519_pub_key *pub_key,
                                        xtt_ed25519_priv_key *priv_key);
 
+int xtt_crypto_extract_ed25519_private_key(unsigned char *out,
+                                           xtt_ed25519_priv_key *priv_key);
+
 int xtt_crypto_sign_ed25519(unsigned char* signature_out,
                             const unsigned char* msg,
                             uint16_t msg_len,

--- a/src/libsodium_wrapper.c
+++ b/src/libsodium_wrapper.c
@@ -198,6 +198,12 @@ int xtt_crypto_create_ed25519_key_pair(xtt_ed25519_pub_key *pub_key,
     return crypto_sign_ed25519_keypair(pub_key->data, priv_key->data);
 }
 
+int xtt_crypto_extract_ed25519_private_key(unsigned char *out,
+                                           xtt_ed25519_priv_key *priv_key)
+{
+    return crypto_sign_ed25519_sk_to_seed(out, priv_key->data);
+}
+
 int xtt_crypto_sign_ed25519(unsigned char* signature_out,
                             const unsigned char* msg,
                             uint16_t msg_len,


### PR DESCRIPTION
Our `xtt_ed25519_priv_key` type is actually libsodium's private key type, which caches some of the private key operations. Libsodium has a function for extracting the actual private key from this structure, so this patch adds a wrapper for this to `xtt/crypto_wrapper.h`