### PR TITLE
Add a c-string version of `xtt_identity_type`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 
 project(xtt
-        VERSION "0.5.1"
+        VERSION "0.5.2"
         )
 
 set(XTT_VERSION ${PROJECT_VERSION})

--- a/include/xtt/crypto_types.h
+++ b/include/xtt/crypto_types.h
@@ -68,6 +68,7 @@ typedef struct {unsigned char data[32];} xtt_signing_nonce;
 typedef struct {unsigned char data[8];} xtt_session_id_seed;
 typedef struct {unsigned char data[16];} xtt_session_id;
 typedef struct {unsigned char data[16];} xtt_identity_type;
+typedef struct {char data[33];} xtt_identity_string;
 extern const xtt_identity_type xtt_null_identity;
 typedef struct {unsigned char data[130];} xtt_server_cookie;
 
@@ -113,6 +114,10 @@ typedef struct {unsigned char data[16];} xtt_aes256_mac;
 typedef struct {unsigned char data[64];} xtt_sha512;
 
 typedef struct {unsigned char data[64];} xtt_blake2b;
+
+int
+xtt_identity_to_string(const xtt_identity_type *identity_in,
+                       xtt_identity_string *string_out);
 
 #ifdef __cplusplus
 }

--- a/src/crypto_types.c
+++ b/src/crypto_types.c
@@ -18,6 +18,27 @@
 
 #include <xtt/crypto_types.h>
 
+#include <stdio.h>
+
 const xtt_identity_type xtt_null_identity = {{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}};
 
 const xtt_certificate_root_id xtt_null_server_root_id = {{0}};
+
+int
+xtt_identity_to_string(const xtt_identity_type *identity_in,
+                       xtt_identity_string *string_out)
+{
+    char *ptr = string_out->data;
+
+    for (size_t i=0; i<sizeof(xtt_identity_type); ++i) {
+        int encode_ret = sprintf(ptr, "%02X", identity_in->data[i]);
+        if (encode_ret != 2) {
+            return -1;
+        }
+        ptr += 2;
+    }
+
+    string_out->data[sizeof(xtt_identity_string)-1] = 0;
+
+    return 0;
+}


### PR DESCRIPTION
Also adds a conversion function for going from identity_type -> string.

This does not add a conversion for going the other way, string -> identity_type.
That is a bit more fraught, and doesn't seem necessary right now.