### PR TITLE
Add utilities for converting longterm keys to ASN.1 and X509 formats

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 
 project(xtt
-        VERSION "0.5.2"
+        VERSION "0.5.3"
         )
 
 set(XTT_VERSION ${PROJECT_VERSION})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,12 +46,14 @@ set(XTT_SRCS
         src/context.c
         src/crypto_types.c
         src/messages.c
+        src/asn1_utilities.c
         src/internal/byte_utils.c
         src/internal/key_derivation.c
         src/internal/crypto_utils.c
         src/internal/message_utils.c
         src/internal/server_cookie.c
         src/internal/signatures.c
+        src/internal/asn1.c
         )
 
 ################################################################################
@@ -174,3 +176,8 @@ endif()
 ################################################################################
 # Current disabled, while moving rapidly. TODO!!!
 # add_subdirectory(test)
+
+################################################################################
+# Util
+################################################################################
+add_subdirectory(util)

--- a/include/xtt/asn1_utilities.h
+++ b/include/xtt/asn1_utilities.h
@@ -1,6 +1,6 @@
 /******************************************************************************
  *
- * Copyright 2018 Xaptum, Inc.
+ * Copyright 2017 Xaptum, Inc.
  * 
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,18 +16,31 @@
  *
  *****************************************************************************/
 
-#ifndef XTT_H
-#define XTT_H
+#ifndef XTT_ASN1_UTILITIES_H
+#define XTT_ASN1_UTILITIES_H
 #pragma once
 
-#include <xtt/certificates.h>
-#include <xtt/context.h>
-#include <xtt/crypto_wrapper.h>
 #include <xtt/crypto_types.h>
-#include <xtt/daa_wrapper.h>
-#include <xtt/asn1_utilities.h>
-#include <xtt/return_codes.h>
-#include <xtt/messages.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define XTT_X509_CERTIFICATE_LENGTH 276
+
+#define XTT_ASN1_PRIVATE_KEY_LENGTH 48
+
+int xtt_x509_from_ed25519_keypair(const xtt_ed25519_pub_key *pub_key_in,
+                                  const xtt_ed25519_priv_key *priv_key_in,
+                                  const xtt_identity_type *common_name,
+                                  unsigned char *certificate_out);
+
+int xtt_asn1_from_ed25519_private_key(const xtt_ed25519_priv_key *priv_key_in,
+                                      unsigned char *asn1_out);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 

--- a/include/xtt/crypto_wrapper.h
+++ b/include/xtt/crypto_wrapper.h
@@ -68,7 +68,7 @@ int xtt_crypto_create_ed25519_key_pair(xtt_ed25519_pub_key *pub_key,
                                        xtt_ed25519_priv_key *priv_key);
 
 int xtt_crypto_extract_ed25519_private_key(unsigned char *out,
-                                           xtt_ed25519_priv_key *priv_key);
+                                           const xtt_ed25519_priv_key *priv_key);
 
 int xtt_crypto_sign_ed25519(unsigned char* signature_out,
                             const unsigned char* msg,

--- a/src/asn1_utilities.c
+++ b/src/asn1_utilities.c
@@ -1,0 +1,68 @@
+/******************************************************************************
+ *
+ * Copyright 2017 Xaptum, Inc.
+ * 
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ * 
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License
+ *
+ *****************************************************************************/
+
+#include <xtt/asn1_utilities.h>
+
+#include "internal/asn1.h"
+
+#include <xtt/crypto_wrapper.h>
+#include <xtt/crypto_types.h>
+
+#include <assert.h>
+#include <string.h>
+
+int xtt_x509_from_ed25519_keypair(const xtt_ed25519_pub_key *pub_key_in,
+                                  const xtt_ed25519_priv_key *priv_key_in,
+                                  const xtt_identity_type *common_name,
+                                  unsigned char *certificate_out)
+{
+    assert(XTT_X509_CERTIFICATE_LENGTH == get_certificate_length());
+
+    unsigned char *pub_key_location;
+    unsigned char *signature_location;
+    unsigned char *signature_input_location;
+    size_t signature_input_length;
+    xtt_identity_string common_name_as_string;
+    int convert_ret = xtt_identity_to_string(common_name, &common_name_as_string);
+    if (0 != convert_ret)
+        return -1;
+    build_x509_skeleton(certificate_out, &pub_key_location, &signature_location, &signature_input_location, &signature_input_length, common_name_as_string.data);
+
+    memcpy(pub_key_location, pub_key_in->data, sizeof(xtt_ed25519_pub_key));
+
+    int sign_ret = xtt_crypto_sign_ed25519(signature_location, signature_input_location, signature_input_length, priv_key_in);
+    if (0 != sign_ret) {
+        return -1;
+    } else {
+        return 0;
+    }
+}
+
+int xtt_asn1_from_ed25519_private_key(const xtt_ed25519_priv_key *priv_key_in,
+                                      unsigned char *asn1_out)
+{
+    unsigned char *privkey_location;
+    build_asn1_key_skeleton(asn1_out, &privkey_location);
+
+    int ret = xtt_crypto_extract_ed25519_private_key(privkey_location, priv_key_in);
+    if (0 != ret) {
+        return -1;
+    } else {
+        return 0;
+    }
+}

--- a/src/internal/asn1.c
+++ b/src/internal/asn1.c
@@ -1,0 +1,343 @@
+/******************************************************************************
+ *
+ * Copyright 2017 Xaptum, Inc.
+ * 
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ * 
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License
+ *
+ *****************************************************************************/
+
+#include "asn1.h"
+
+#include <xtt/crypto_wrapper.h>
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <assert.h>
+#include <string.h>
+#include <time.h>
+#include <stdio.h>
+
+const unsigned char SEQUENCE_TAG = 0x30;
+const unsigned char SET_TAG = 0x31;
+const unsigned char INTEGER_TAG = 0x02;
+const unsigned char OBJECTIDENTIFIER_TAG = 0x06;
+const unsigned char UTCTIME_TAG = 0x17;
+const unsigned char BITSTRING_TAG = 0x03;
+const unsigned char OCTETSTRING_TAG = 0x04;
+
+const unsigned char COMMONNAME_OID[] = {0x55, 0x04, 0x03};
+const unsigned char ED25519_OID[] = {0x2B, 0x65, 0x70};
+
+const unsigned char ONEASYMMETRICKEY_VERSION = 0x00;
+
+const unsigned char UTF8STRING_ATTRTYPE = 0x0C;
+
+const int VALIDITY_YEARS = 1;
+
+enum { UTC_LENGTH = 13 };                                                               // YYMMDDhhssmm'Z'
+enum { NAME_LENGTH = 32 };
+enum { RAW_PRIVATE_KEY_LENGTH = 32 };
+enum { PUBLIC_KEY_LENGTH = 32 };
+enum { SIGNATURE_LENGTH = 64 };
+
+enum { serial_num_length = 1 + 1 + 20 };                                                // tag(1) + length(1) + content(20)
+
+enum { ed25519_oid_length = 1 + 1 + 3 };                                                // tag(1) + length(1) + content(3)
+enum { ed25519_algid_length = 1 + 1 + ed25519_oid_length };                             // tag(1) + length(1) + ed25519_oid_length
+
+enum { name_string_length = 1 + 1 + NAME_LENGTH };                                               // tag(1) + length(1) + content(32)
+enum { name_oid_length = 1 + 1 + 3 };                                                   // tag(1) + length(1) + content(3)
+enum { name_attr_tandv_length = 1 + 1 + name_oid_length + name_string_length };         // tag(1) + length(1) + name_oid_length + name_string_length
+enum { rdn_length = 1 + 1 + name_attr_tandv_length };                                   // tag(1) + length(1) + name_attr_tandv_length
+enum { name_length = 1 + 1 + rdn_length };                                              // tag(1) + length(1) + rdn_length
+
+enum { utctime_length = 1 + 1 + UTC_LENGTH };                                           // tag(1) + length(1) + content(13) 'YYMMDDhhssmmZ'
+enum { validity_length = 1 + 1 + 2*utctime_length };                                    // tag(1) + length(1) + 2*utctime_length (one for notBefore, other for notAfter)
+
+enum { pubkey_bitstring_length = 1 + 1 + 1 + PUBLIC_KEY_LENGTH };                       // tag(1) + length(1) + padding(1) + content(32)
+enum { subjectpublickeyinfo_length = 1 + 1 + ed25519_algid_length + pubkey_bitstring_length };    // tag(1) + length(1) + ed25519_algid_length + pubkey_bitstring_length
+
+enum { tbs_certificate_length = 1 + 2 + serial_num_length + ed25519_algid_length + name_length + validity_length + name_length + subjectpublickeyinfo_length };
+
+enum { signature_algorithm_length = ed25519_algid_length }; 
+
+enum { signature_value_length = 1 + 1 + 1 + SIGNATURE_LENGTH };                         // tag(1) + length(1) + padding(1) + content(64)
+
+enum { certificate_length = 1 + 3 + tbs_certificate_length + signature_algorithm_length + signature_value_length };
+
+enum { asn1_privatekey_version_length = 1 + 1 + 1 };                                    // tag(1) + length(1) + content(1)
+enum { asn1_curveprivatekey_length = 1 + 1 + RAW_PRIVATE_KEY_LENGTH };
+enum { asn1_privatekey_total_length = 1 + 1 + asn1_curveprivatekey_length };            // tag(1) + length(1) + asn1_curveprivatekey_length
+enum { asn1_privatekey_length = 1 + 1 + asn1_privatekey_version_length + ed25519_algid_length + asn1_privatekey_total_length };
+
+size_t
+get_certificate_length()
+{
+    return certificate_length;
+}
+
+void
+build_x509_skeleton(unsigned char *certificate_out,
+                    unsigned char **pubkey_location,
+                    unsigned char **signature_location,
+                    unsigned char **signature_input_location,
+                    size_t *signature_input_length,
+                    const char *common_name)
+{
+    unsigned char *current_loc = certificate_out;
+
+    set_as_sequence(&current_loc);
+    set_length(&current_loc, certificate_length - 1 - 3);
+
+    *signature_input_location = current_loc;
+    *signature_input_length = tbs_certificate_length;
+
+    build_tbs_certificate(&current_loc, pubkey_location, common_name);
+
+    build_signature_algorithm(&current_loc);
+
+    *current_loc = BITSTRING_TAG;
+    current_loc += 1;
+    set_length(&current_loc, signature_value_length - 1 - 1);
+
+    // Add a 0x00, to indicate we didn't need to pad (signature is always a multiple of 8bits)
+    *current_loc = 0x00;
+    current_loc += 1;
+
+    *signature_location = current_loc;
+}
+
+void
+build_privkey_version(unsigned char **current_loc)
+{
+    **current_loc = INTEGER_TAG;
+    *current_loc += 1;
+    set_length(current_loc, 1);
+
+    **current_loc = ONEASYMMETRICKEY_VERSION;
+
+    *current_loc += 1;
+}
+
+void
+build_curveprivatekey(unsigned char **current_loc,
+                      unsigned char **privatekey_location)
+{
+    **current_loc = OCTETSTRING_TAG;
+    *current_loc += 1;
+    set_length(current_loc, asn1_privatekey_total_length - 1 - 1);
+
+    **current_loc = OCTETSTRING_TAG;
+    *current_loc += 1;
+    set_length(current_loc, asn1_curveprivatekey_length - 1 - 1);
+
+    *privatekey_location = *current_loc;
+}
+
+void
+build_asn1_key_skeleton(unsigned char *asn1_out,
+                        unsigned char **privkey_location)
+{
+    unsigned char *current_loc = asn1_out;
+
+    set_as_sequence(&current_loc);
+    set_length(&current_loc, asn1_privatekey_length - 1 - 1);
+
+    build_privkey_version(&current_loc);
+
+    build_signature_algorithm(&current_loc);
+
+    build_curveprivatekey(&current_loc, privkey_location);
+}
+
+void
+set_as_sequence(unsigned char **current_loc)
+{
+    **current_loc = SEQUENCE_TAG;
+    *current_loc += 1;
+}
+
+void
+set_as_set(unsigned char **current_loc)
+{
+    **current_loc = SET_TAG;
+    *current_loc += 1;
+}
+
+void
+build_tbs_certificate(unsigned char **current_loc,
+                      unsigned char **pubkey_location,
+                      const char *common_name)
+{
+    set_as_sequence(current_loc);
+    set_length(current_loc, tbs_certificate_length - 1 - 2);
+
+    build_serial_number(current_loc);
+
+    build_signature_algorithm(current_loc);
+
+    build_name(current_loc, common_name);    // issuer name
+
+    build_validity(current_loc);
+
+    build_name(current_loc, common_name);    // subject name
+
+    build_subjectpublickeyinfo(current_loc, pubkey_location);
+}
+
+void
+set_length(unsigned char **current_loc,
+           size_t length)
+{
+    if (length < 127) {
+        **current_loc = length;
+        *current_loc += 1;
+    } else if (length < UINT8_MAX) {
+        (*current_loc)[0] = 0x80 + 1;   // Set msb to 1, to indicate a long format, and add one for the one next block
+        (*current_loc)[1] = length;
+        *current_loc += 2;
+    } else if (length < UINT16_MAX) {
+        (*current_loc)[0] = 0x80 + 2;   // Set msb to 1, to indicate a long format, and add two for the two next blocks
+        (*current_loc)[1] = length >> 8;
+        (*current_loc)[2] = length & 0xFF;
+        *current_loc += 3;
+    } else {
+        // None of our lengths should require more than 2 bytes to represent
+        exit(1);
+    }
+}
+
+void
+build_signature_algorithm(unsigned char **current_loc)
+{
+    set_as_sequence(current_loc);
+    set_length(current_loc, ed25519_algid_length - 1 - 1);
+
+    **current_loc = OBJECTIDENTIFIER_TAG;
+    *current_loc += 1;
+    set_length(current_loc, ed25519_oid_length - 1 - 1);
+
+    memcpy(*current_loc, ED25519_OID, 3);
+    *current_loc += 3;
+}
+
+void
+build_serial_number(unsigned char **current_loc)
+{
+    const size_t len = serial_num_length - 1 - 1;
+
+    **current_loc = INTEGER_TAG;
+    *current_loc += 1;
+    set_length(current_loc, len);
+
+    assert(len == 20);
+    // Nb. We're only generating 19 bytes of randomness
+    xtt_crypto_get_random(*current_loc, len-1);
+    (*current_loc)[0] = 0x00;   // clear MSB, to ensure it's not a signed integer
+
+    *current_loc += len;
+}
+
+void
+build_name(unsigned char **current_loc,
+           const char *common_name)
+{
+    set_as_sequence(current_loc);
+    set_length(current_loc, name_length - 1 - 1);
+
+    set_as_set(current_loc);
+    set_length(current_loc, rdn_length - 1 - 1);
+
+    set_as_sequence(current_loc);
+    set_length(current_loc, name_attr_tandv_length - 1 - 1);
+
+    **current_loc = OBJECTIDENTIFIER_TAG;
+    *current_loc += 1;
+    set_length(current_loc, name_oid_length - 1 - 1);
+    memcpy(*current_loc, COMMONNAME_OID, 3);
+    *current_loc += 3;
+
+    **current_loc = UTF8STRING_ATTRTYPE;
+    *current_loc += 1;
+    set_length(current_loc, NAME_LENGTH);
+    memcpy(*current_loc, common_name, NAME_LENGTH);
+    *current_loc += NAME_LENGTH;
+}
+
+void
+build_validity(unsigned char **current_loc)
+{
+    set_as_sequence(current_loc);
+    set_length(current_loc, validity_length - 1 - 1);
+
+    char not_before_time[14];
+    assert(sizeof(not_before_time) == UTC_LENGTH + 1);      // for the null-terminator
+    char not_after_time[14];
+    assert(sizeof(not_after_time) == UTC_LENGTH + 1);      // for the null-terminator
+    get_validity_times(not_before_time, not_after_time);
+
+    **current_loc = UTCTIME_TAG;
+    *current_loc += 1;
+    set_length(current_loc, utctime_length - 1 - 1);
+    memcpy(*current_loc, not_before_time, UTC_LENGTH);
+    *current_loc += UTC_LENGTH;
+
+    **current_loc = UTCTIME_TAG;
+    *current_loc += 1;
+    set_length(current_loc, utctime_length - 1 - 1);
+    memcpy(*current_loc, not_after_time, UTC_LENGTH);
+    *current_loc += UTC_LENGTH;
+}
+
+void
+build_subjectpublickeyinfo(unsigned char **current_loc, unsigned char **pubkey_location)
+{
+    set_as_sequence(current_loc);
+    set_length(current_loc, subjectpublickeyinfo_length - 1 - 1);
+
+    build_signature_algorithm(current_loc);
+
+    **current_loc = BITSTRING_TAG;
+    *current_loc += 1;
+    set_length(current_loc, pubkey_bitstring_length - 1 - 1);
+
+    // Add a 0x00, to indicate we didn't need to pad (pub key is always a multiple of 8bits)
+    **current_loc = 0x00;
+    *current_loc += 1;
+
+    *pubkey_location = *current_loc;
+
+    // Increment, to make space for pub key (caller will copy it in)
+    *current_loc += sizeof(xtt_ed25519_pub_key);
+}
+
+void
+get_validity_times(char *not_before_time, char *not_after_time)
+{
+    time_t now_timet = time(NULL);
+    struct tm *now = gmtime(&now_timet);
+
+    snprintf(not_before_time,
+             UTC_LENGTH + 1,
+             "%02d%02d%02d000000Z",
+             now->tm_year - 100,
+             now->tm_mon + 1,
+             now->tm_mday);
+
+    snprintf(not_after_time,
+             UTC_LENGTH + 1,
+             "%02d%02d%02d000000Z",
+             now->tm_year - 100 + VALIDITY_YEARS,
+             now->tm_mon + 1,
+             now->tm_mday);
+}

--- a/src/internal/asn1.h
+++ b/src/internal/asn1.h
@@ -1,0 +1,90 @@
+/******************************************************************************
+ *
+ * Copyright 2017 Xaptum, Inc.
+ * 
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ * 
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License
+ *
+ *****************************************************************************/
+
+#ifndef XTT_INTERNAL_ASN1_H
+#define XTT_INTERNAL_ASN1_H
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stddef.h>
+
+size_t
+get_certificate_length();
+
+void
+set_length(unsigned char **current_loc,
+           size_t length);
+
+void
+build_x509_skeleton(unsigned char *certificate_out,
+                    unsigned char **pubkey_location,
+                    unsigned char **signature_location,
+                    unsigned char **signature_input_location,
+                    size_t *signature_input_length,
+                    const char *common_name);
+
+void
+build_asn1_key_skeleton(unsigned char *asn1_out,
+                        unsigned char **privkey_location);
+
+void
+set_as_sequence(unsigned char **current_loc);
+
+void
+set_as_set(unsigned char **current_loc);
+
+void
+build_tbs_certificate(unsigned char **current_loc,
+                      unsigned char **pubkey_location,
+                      const char *common_name);
+
+void
+build_signature_algorithm(unsigned char **current_loc);
+
+void
+build_serial_number(unsigned char **current_loc);
+
+void
+build_name(unsigned char **current_loc,
+           const char *common_name);
+
+void
+build_validity(unsigned char **current_loc);
+
+void
+build_subjectpublickeyinfo(unsigned char **current_loc, unsigned char **pubkey_location);
+
+void
+get_validity_times(char *not_before_time, char *not_after_time);
+
+void
+build_privkey_version(unsigned char **current_loc);
+
+void
+build_curveprivatekey(unsigned char **current_loc,
+                      unsigned char **privatekey_location);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+

--- a/src/libsodium_wrapper.c
+++ b/src/libsodium_wrapper.c
@@ -199,7 +199,7 @@ int xtt_crypto_create_ed25519_key_pair(xtt_ed25519_pub_key *pub_key,
 }
 
 int xtt_crypto_extract_ed25519_private_key(unsigned char *out,
-                                           xtt_ed25519_priv_key *priv_key)
+                                           const xtt_ed25519_priv_key *priv_key)
 {
     return crypto_sign_ed25519_sk_to_seed(out, priv_key->data);
 }

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -1,0 +1,27 @@
+# Copyright 2017 Xaptum, Inc.
+# 
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+# 
+#        http://www.apache.org/licenses/LICENSE-2.0
+# 
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License
+
+cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
+
+add_executable(xtt_generate_ed25519_keys xtt_generate_ed25519_keys.c)
+
+target_link_libraries(xtt_generate_ed25519_keys
+        PRIVATE xtt 
+        )
+
+add_executable(xtt_wrap_keys_as_ASN1 xtt_wrap_keys_as_ASN1.c)
+
+target_link_libraries(xtt_wrap_keys_as_ASN1
+        PRIVATE xtt
+        )

--- a/util/xtt_generate_ed25519_keys.c
+++ b/util/xtt_generate_ed25519_keys.c
@@ -1,0 +1,105 @@
+/******************************************************************************
+ *
+ * Copyright 2018 Xaptum, Inc.
+ * 
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ * 
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License
+ *
+ *****************************************************************************/
+
+#include <xtt/crypto_wrapper.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+
+struct cli_args {
+    char *pubkey_out_filename;
+    char *privkey_out_filename;
+};
+
+int save_to_file(unsigned char *buffer, size_t buffer_length, const char *filename);
+
+void parse_cli(int argc, char *argv[], struct cli_args *args);
+
+int main(int argc, char *argv[])
+{
+    int ret = 0;
+
+    struct cli_args args;
+    parse_cli(argc, argv, &args);
+
+    printf("Generating Ed25519 keys to files '%s' and '%s'...\n", args.pubkey_out_filename, args.privkey_out_filename);
+    xtt_ed25519_pub_key pub;
+    xtt_ed25519_priv_key priv;
+    if (0 != xtt_crypto_create_ed25519_key_pair(&pub, &priv)) {
+        fprintf(stderr, "Error creating Ed25519 keypair\n");
+        ret = 1;
+        goto finish;
+    }
+
+    if (0 != save_to_file(pub.data, sizeof(xtt_ed25519_pub_key), args.pubkey_out_filename)) {
+        ret = 1;
+        goto finish;
+    }
+
+    if (0 != save_to_file(priv.data, sizeof(xtt_ed25519_priv_key), args.privkey_out_filename)) {
+        ret = 1;
+        goto finish;
+    }
+
+    printf("\tok\n");
+finish:
+    return ret;
+}
+
+void parse_cli(int argc, char *argv[], struct cli_args *args)
+{
+    const char *usage = "usage: %s [public-key-out-file=pub.bin] [private-key-out-file=priv.bin]\n"
+                        "\tIf either public-key-out-file or private-key-out-file is given, BOTH must be given\n";
+
+    if (3 == argc) {
+        args->pubkey_out_filename = argv[1];
+        args->privkey_out_filename = argv[2];
+    } else if (1 == argc) {
+        args->pubkey_out_filename = "pub.bin";
+        args->privkey_out_filename = "priv.bin";
+    } else {
+        fprintf(stderr, "Incorrect number of arguments given\n");
+        fprintf(stderr, usage, argv[0]);
+
+        exit(1);
+    }
+
+}
+
+int save_to_file(unsigned char *buffer, size_t buffer_length, const char *filename)
+{
+    FILE *file_ptr = fopen(filename, "wb");
+
+    if (NULL == file_ptr)
+        return -1;
+
+    int ret = 0;
+
+    size_t bytes_written = fwrite(buffer, 1, buffer_length, file_ptr);
+
+    if (buffer_length != bytes_written) {
+        fprintf(stderr, "Error writing to file '%s'\n", filename);
+        ret = -1;
+        goto cleanup;
+    }
+
+cleanup:
+    (void)fclose(file_ptr);
+
+    return ret;
+}

--- a/util/xtt_wrap_keys_as_ASN1.c
+++ b/util/xtt_wrap_keys_as_ASN1.c
@@ -1,0 +1,181 @@
+/******************************************************************************
+ *
+ * Copyright 2018 Xaptum, Inc.
+ * 
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ * 
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License
+ *
+ *****************************************************************************/
+
+#include <xtt.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#define SERIALIZED_NAME_LENGTH 32   // 16 ASCII-encoded bytes
+
+struct cli_args {
+    char *name_in_filename;
+    char *pubkey_in_filename;
+    char *privkey_in_filename;
+    char *cert_out_filename;
+    char *priv_out_filename;
+};
+
+int save_to_file(unsigned char *buffer, size_t buffer_length, const char *filename);
+
+int read_from_file(const char *filename, unsigned char *buffer, size_t bytes_to_read);
+
+void parse_cli(int argc, char *argv[], struct cli_args *args);
+
+int main(int argc, char *argv[])
+{
+    int ret = 0;
+
+    struct cli_args args;
+    parse_cli(argc, argv, &args);
+
+    printf("Saving keys from files '%s' and '%s' to certificate '%s', with Common Name from '%s'...\n",
+           args.pubkey_in_filename,
+           args.privkey_in_filename,
+           args.cert_out_filename,
+           args.name_in_filename);
+
+    xtt_identity_type name_buf;
+    if (read_from_file(args.name_in_filename, name_buf.data, sizeof(xtt_identity_type))) {
+        fprintf(stderr, "Error reading common name in from file '%s'\n", args.name_in_filename);
+        ret = 1;
+        goto finish;
+    }
+
+    xtt_ed25519_pub_key pubkey_buf;
+    if (read_from_file(args.pubkey_in_filename, pubkey_buf.data, sizeof(xtt_ed25519_pub_key))) {
+        fprintf(stderr, "Error reading public key in from file '%s'\n", args.pubkey_in_filename);
+        ret = 1;
+        goto finish;
+    }
+
+    xtt_ed25519_priv_key privkey_buf;
+    if (read_from_file(args.privkey_in_filename, privkey_buf.data, sizeof(xtt_ed25519_priv_key))) {
+        fprintf(stderr, "Error reading private key in from file '%s'\n", args.privkey_in_filename);
+        ret = 1;
+        goto finish;
+    }
+
+    unsigned char cert_buf[XTT_X509_CERTIFICATE_LENGTH];
+    if (0 != xtt_x509_from_ed25519_keypair(&pubkey_buf, &privkey_buf, &name_buf, cert_buf)) {
+        fprintf(stderr, "Error creating X509 certificate\n");
+        ret = 1;
+        goto finish;
+    }
+
+    if (0 != save_to_file(cert_buf, sizeof(cert_buf), args.cert_out_filename)) {
+        fprintf(stderr, "Error saving X509 certificate to file\n");
+        ret = 1;
+        goto finish;
+    }
+
+    unsigned char asn1_priv_buf[XTT_ASN1_PRIVATE_KEY_LENGTH];
+    if (0 != xtt_asn1_from_ed25519_private_key(&privkey_buf, asn1_priv_buf)) {
+        fprintf(stderr, "Error creating ASN.1 private key\n");
+        ret = 1;
+        goto finish;
+    }
+
+    if (0 != save_to_file(asn1_priv_buf, sizeof(asn1_priv_buf), args.priv_out_filename)) {
+        fprintf(stderr, "Error saving ASN.1 private key to file\n");
+        ret = 1;
+        goto finish;
+    }
+
+    printf("\tok\n");
+finish:
+    return ret;
+}
+
+
+void parse_cli(int argc, char *argv[], struct cli_args *args)
+{
+    const char *usage = "usage: %s <common-name-file> <public-key-in-file> <private-key-in-file> [certificate-out-file] [private-key-out-file]\n"
+                        "\tidentity-file            - File with XTT identity\n"
+                        "\tpublic-key-in-file       - File with raw Ed25519 public key\n"
+                        "\tprivate-key-in-file      - File with raw Ed25519 private key\n"
+                        "\tcertificate-out-file     - Location to save X509 self-signed certificate         (default: 'cert.bin')\n"
+                        "\tprivate-key-out-file     - Location to save ASN.1-encoded Ed25519 private key    (default: 'priv_asn1.bin')\n"
+                        "\t\tIf either cert-out-file or private-key-out-file is given, BOTH must be given\n";
+
+    if (6 == argc) {
+        args->name_in_filename = argv[1];
+        args->pubkey_in_filename = argv[2];
+        args->privkey_in_filename = argv[3];
+        args->cert_out_filename = argv[4];
+        args->priv_out_filename = argv[5];
+    } else if (4 == argc) {
+        args->name_in_filename = argv[1];
+        args->pubkey_in_filename = argv[2];
+        args->privkey_in_filename = argv[3];
+        args->cert_out_filename = "cert.bin";
+        args->priv_out_filename = "priv_asn1.bin";
+    } else {
+        fprintf(stderr, "Incorrect number of arguments given\n");
+        fprintf(stderr, usage, argv[0]);
+
+        exit(1);
+    }
+}
+
+int save_to_file(unsigned char *buffer, size_t buffer_length, const char *filename)
+{
+    FILE *file_ptr = fopen(filename, "wb");
+
+    if (NULL == file_ptr)
+        return -1;
+
+    int ret = 0;
+
+    size_t bytes_written = fwrite(buffer, 1, buffer_length, file_ptr);
+
+    if (buffer_length != bytes_written) {
+        fprintf(stderr, "Error writing to file '%s'\n", filename);
+        ret = -1;
+        goto cleanup;
+    }
+
+cleanup:
+    (void)fclose(file_ptr);
+
+    return ret;
+}
+
+int read_from_file(const char *filename, unsigned char *buffer, size_t bytes_to_read)
+{
+    FILE *file_ptr = fopen(filename, "rb");
+
+    if (NULL == file_ptr)
+        return -1;
+
+    int ret = 0;
+
+    size_t bytes_read = fread(buffer, 1, bytes_to_read, file_ptr);
+
+    if (bytes_to_read != bytes_read) {
+        fprintf(stderr, "Error reading file '%s'\n", filename);
+        ret = -1;
+        goto cleanup;
+    }
+
+cleanup:
+    (void)fclose(file_ptr);
+
+    return ret;
+}
+


### PR DESCRIPTION
Currently, to use the output from an XTT handshake to connect to the Xaptum ENF, the only option is via a TLS handshake. This means the Ed25519 keypair generated during the XTT handshake must be converted into a self-signed X509 certificate.