### PR TITLE
Asn1 safety and portability

### DIFF
--- a/examples/xtt_client.c
+++ b/examples/xtt_client.c
@@ -661,7 +661,7 @@ int report_results(xtt_identity_type *requested_client_id,
 
     // Save longterm keypair as X509 certificate and ASN.1-encoded private key
     unsigned char cert_buf[XTT_X509_CERTIFICATE_LENGTH];
-    if (0 != xtt_x509_from_ed25519_keypair(&my_longterm_key, &my_longterm_private_key, &my_assigned_id, cert_buf)) {
+    if (0 != xtt_x509_from_ed25519_keypair(&my_longterm_key, &my_longterm_private_key, &my_assigned_id, cert_buf, sizeof(cert_buf))) {
         fprintf(stderr, "Error creating X509 certificate\n");
         return 1;
     }
@@ -671,7 +671,7 @@ int report_results(xtt_identity_type *requested_client_id,
         return 1;
     }
     unsigned char asn1_priv_buf[XTT_ASN1_PRIVATE_KEY_LENGTH];
-    if (0 != xtt_asn1_from_ed25519_private_key(&my_longterm_private_key, asn1_priv_buf)) {
+    if (0 != xtt_asn1_from_ed25519_private_key(&my_longterm_private_key, asn1_priv_buf, sizeof(asn1_priv_buf))) {
         fprintf(stderr, "Error creating ASN.1 private key\n");
         return 1;
     }

--- a/include/xtt/asn1_utilities.h
+++ b/include/xtt/asn1_utilities.h
@@ -37,10 +37,12 @@ size_t xtt_asn1_private_key_length(void);
 int xtt_x509_from_ed25519_keypair(const xtt_ed25519_pub_key *pub_key_in,
                                   const xtt_ed25519_priv_key *priv_key_in,
                                   const xtt_identity_type *common_name,
-                                  unsigned char *certificate_out);
+                                  unsigned char *certificate_out,
+                                  size_t certificate_out_length);
 
 int xtt_asn1_from_ed25519_private_key(const xtt_ed25519_priv_key *priv_key_in,
-                                      unsigned char *asn1_out);
+                                      unsigned char *asn1_out,
+                                      size_t asn1_out_length);
 
 #ifdef __cplusplus
 }

--- a/include/xtt/asn1_utilities.h
+++ b/include/xtt/asn1_utilities.h
@@ -20,6 +20,8 @@
 #define XTT_ASN1_UTILITIES_H
 #pragma once
 
+#include <stddef.h>
+
 #include <xtt/crypto_types.h>
 
 #ifdef __cplusplus
@@ -27,8 +29,10 @@ extern "C" {
 #endif
 
 #define XTT_X509_CERTIFICATE_LENGTH 276
+size_t xtt_x509_certificate_length(void);
 
 #define XTT_ASN1_PRIVATE_KEY_LENGTH 48
+size_t xtt_asn1_private_key_length(void);
 
 int xtt_x509_from_ed25519_keypair(const xtt_ed25519_pub_key *pub_key_in,
                                   const xtt_ed25519_priv_key *priv_key_in,
@@ -43,4 +47,3 @@ int xtt_asn1_from_ed25519_private_key(const xtt_ed25519_priv_key *priv_key_in,
 #endif
 
 #endif
-

--- a/src/asn1_utilities.c
+++ b/src/asn1_utilities.c
@@ -39,7 +39,8 @@ size_t xtt_asn1_private_key_length(void)
 int xtt_x509_from_ed25519_keypair(const xtt_ed25519_pub_key *pub_key_in,
                                   const xtt_ed25519_priv_key *priv_key_in,
                                   const xtt_identity_type *common_name,
-                                  unsigned char *certificate_out)
+                                  unsigned char *certificate_out,
+                                  size_t certificate_out_length)
 {
     assert(XTT_X509_CERTIFICATE_LENGTH == get_certificate_length());
 
@@ -48,9 +49,14 @@ int xtt_x509_from_ed25519_keypair(const xtt_ed25519_pub_key *pub_key_in,
     unsigned char *signature_input_location;
     size_t signature_input_length;
     xtt_identity_string common_name_as_string;
+
+    if (certificate_out_length < XTT_X509_CERTIFICATE_LENGTH)
+      return -1;
+
     int convert_ret = xtt_identity_to_string(common_name, &common_name_as_string);
     if (0 != convert_ret)
         return -1;
+
     build_x509_skeleton(certificate_out, &pub_key_location, &signature_location, &signature_input_location, &signature_input_length, common_name_as_string.data);
 
     memcpy(pub_key_location, pub_key_in->data, sizeof(xtt_ed25519_pub_key));
@@ -64,9 +70,14 @@ int xtt_x509_from_ed25519_keypair(const xtt_ed25519_pub_key *pub_key_in,
 }
 
 int xtt_asn1_from_ed25519_private_key(const xtt_ed25519_priv_key *priv_key_in,
-                                      unsigned char *asn1_out)
+                                      unsigned char *asn1_out,
+                                      size_t asn1_out_length)
 {
     unsigned char *privkey_location;
+
+    if (asn1_out_length < XTT_ASN1_PRIVATE_KEY_LENGTH)
+      return -1;
+
     build_asn1_key_skeleton(asn1_out, &privkey_location);
 
     int ret = xtt_crypto_extract_ed25519_private_key(privkey_location, priv_key_in);

--- a/src/asn1_utilities.c
+++ b/src/asn1_utilities.c
@@ -26,6 +26,16 @@
 #include <assert.h>
 #include <string.h>
 
+size_t xtt_x509_certificate_length(void)
+{
+    return XTT_X509_CERTIFICATE_LENGTH;
+}
+
+size_t xtt_asn1_private_key_length(void)
+{
+    return XTT_ASN1_PRIVATE_KEY_LENGTH;
+}
+
 int xtt_x509_from_ed25519_keypair(const xtt_ed25519_pub_key *pub_key_in,
                                   const xtt_ed25519_priv_key *priv_key_in,
                                   const xtt_identity_type *common_name,

--- a/util/xtt_wrap_keys_as_ASN1.c
+++ b/util/xtt_wrap_keys_as_ASN1.c
@@ -72,7 +72,7 @@ int main(int argc, char *argv[])
     }
 
     unsigned char cert_buf[XTT_X509_CERTIFICATE_LENGTH];
-    if (0 != xtt_x509_from_ed25519_keypair(&pubkey_buf, &privkey_buf, &name_buf, cert_buf)) {
+    if (0 != xtt_x509_from_ed25519_keypair(&pubkey_buf, &privkey_buf, &name_buf, cert_buf, sizeof(cert_buf))) {
         fprintf(stderr, "Error creating X509 certificate\n");
         ret = 1;
         goto finish;
@@ -85,7 +85,7 @@ int main(int argc, char *argv[])
     }
 
     unsigned char asn1_priv_buf[XTT_ASN1_PRIVATE_KEY_LENGTH];
-    if (0 != xtt_asn1_from_ed25519_private_key(&privkey_buf, asn1_priv_buf)) {
+    if (0 != xtt_asn1_from_ed25519_private_key(&privkey_buf, asn1_priv_buf, sizeof(asn1_priv_buf))) {
         fprintf(stderr, "Error creating ASN.1 private key\n");
         ret = 1;
         goto finish;


### PR DESCRIPTION
This series improves portability and safety of the asn1 utility functions.

- Exports the certificate length macros as functions for use by wrapper libraries
- Explicitly validates the length of the output buffers for x509 and ASN1 encodings.