### PR TITLE
Add a missing `xtt_` prefix to `generate_server_certificate_ed25519`

### DIFF
--- a/examples/xtt_generate_certificate.c
+++ b/examples/xtt_generate_certificate.c
@@ -81,7 +81,7 @@ int main()
     memcpy(expiry.data, expiry_str, 8);
 
     unsigned char serialized_certificate[XTT_SERVER_CERTIFICATE_ED25519_LENGTH];
-    rc = generate_server_certificate_ed25519(serialized_certificate,
+    rc = xtt_generate_server_certificate_ed25519(serialized_certificate,
                                              &server_id,
                                              &public_key,
                                              &expiry,

--- a/include/xtt/certificates.h
+++ b/include/xtt/certificates.h
@@ -32,12 +32,12 @@ extern "C" {
 struct xtt_server_certificate_raw_type;
 
 xtt_return_code_type
-generate_server_certificate_ed25519(unsigned char *cert_out,
-                                    xtt_identity_type *servers_id,
-                                    xtt_ed25519_pub_key *servers_pub_key,
-                                    xtt_certificate_expiry *expiry,
-                                    xtt_certificate_root_id *roots_id,
-                                    xtt_ed25519_priv_key *roots_priv_key);
+xtt_generate_server_certificate_ed25519(unsigned char *cert_out,
+                                        xtt_identity_type *servers_id,
+                                        xtt_ed25519_pub_key *servers_pub_key,
+                                        xtt_certificate_expiry *expiry,
+                                        xtt_certificate_root_id *roots_id,
+                                        xtt_ed25519_priv_key *roots_priv_key);
 
 uint16_t
 xtt_server_certificate_length_fromsignaturetype(xtt_server_signature_type type);

--- a/src/certificates.c
+++ b/src/certificates.c
@@ -24,12 +24,12 @@
 #include <string.h>
 
 xtt_return_code_type
-generate_server_certificate_ed25519(unsigned char *cert_out,
-                                    xtt_identity_type *servers_id,
-                                    xtt_ed25519_pub_key *servers_pub_key,
-                                    xtt_certificate_expiry *expiry,
-                                    xtt_certificate_root_id *roots_id,
-                                    xtt_ed25519_priv_key *roots_priv_key)
+xtt_generate_server_certificate_ed25519(unsigned char *cert_out,
+                                        xtt_identity_type *servers_id,
+                                        xtt_ed25519_pub_key *servers_pub_key,
+                                        xtt_certificate_expiry *expiry,
+                                        xtt_certificate_root_id *roots_id,
+                                        xtt_ed25519_priv_key *roots_priv_key)
 {
     struct xtt_server_certificate_raw_type *cert_ptr = (struct xtt_server_certificate_raw_type*)cert_out;
 

--- a/test/full_handshake-test-software.c
+++ b/test/full_handshake-test-software.c
@@ -115,7 +115,7 @@ int main()
     xtt_client_id server_id;
     xtt_ed25519_priv_key server_private_key;
     unsigned char serialized_certificate[XTT_SERVER_CERTIFICATE_ED25519_LENGTH];
-    generate_server_certificates(serialized_certificate, &server_id, &server_private_key, &root_id, &root_public_key);
+    xtt_generate_server_certificates(serialized_certificate, &server_id, &server_private_key, &root_id, &root_public_key);
 
     rc = xtt_initialize_server_root_certificate_context_ed25519(&root_certificate,
                                                                 &root_id,
@@ -287,7 +287,7 @@ void generate_server_certificates(unsigned char *cert_serialized_out,
     xtt_certificate_expiry expiry;
     memcpy(expiry.data, "21001231", 8);
 
-    rc = generate_server_certificate_ed25519(cert_serialized_out,
+    rc = xtt_generate_server_certificate_ed25519(cert_serialized_out,
                                              server_id,
                                              &public_key,
                                              &expiry,

--- a/test/full_handshake-test-tpm.c
+++ b/test/full_handshake-test-tpm.c
@@ -86,7 +86,7 @@ int main()
     xtt_client_id server_id;
     xtt_ed25519_priv_key server_private_key;
     unsigned char serialized_certificate[XTT_SERVER_CERTIFICATE_ED25519_LENGTH];
-    generate_server_certificates(serialized_certificate, &server_id, &server_private_key, &root_id, &root_public_key);
+    xtt_generate_server_certificates(serialized_certificate, &server_id, &server_private_key, &root_id, &root_public_key);
 
     rc = xtt_initialize_server_root_certificate_context_ed25519(&root_certificate,
                                                                 &root_id,
@@ -272,7 +272,7 @@ void generate_server_certificates(unsigned char *cert_serialized_out,
     xtt_certificate_expiry expiry;
     memcpy(expiry.data, "21001231", 8);
 
-    rc = generate_server_certificate_ed25519(cert_serialized_out,
+    rc = xtt_generate_server_certificate_ed25519(cert_serialized_out,
                                              server_id,
                                              &public_key,
                                              &expiry,


### PR DESCRIPTION
Fixes #21 