### PR TITLE
Fix cmake config install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,6 +165,13 @@ configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/xtt-config.cmake.in
   INSTALL_DESTINATION ${INSTALL_CONFIGDIR}
 )
 
+install(FILES
+  ${CMAKE_CURRENT_BINARY_DIR}/xtt-config.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/xtt-config-version.cmake
+  DESTINATION ${INSTALL_CONFIGDIR}
+)
+
+
 ################################################################################
 # Examples
 ################################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 list(APPEND CMAKE_MODULE_PATH CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
 
 project(xtt
-        VERSION "0.5.4"
+        VERSION "0.5.5"
         )
 
 set(XTT_VERSION ${PROJECT_VERSION})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 list(APPEND CMAKE_MODULE_PATH CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
 
 project(xtt
-        VERSION "0.5.3"
+        VERSION "0.5.4"
         )
 
 set(XTT_VERSION ${PROJECT_VERSION})


### PR DESCRIPTION
The lines in `CMakeLists.txt` that install the cmake config files got accidentally deleted a few commits back. This restores them.