### PR TITLE
Fix imports for older Linux versions

### DIFF
--- a/src/libsodium_wrapper.c
+++ b/src/libsodium_wrapper.c
@@ -26,6 +26,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <sys/ioctl.h>
+#include <linux/types.h>
 #include <linux/random.h>
 #endif
 


### PR DESCRIPTION
On some older versions of Linux `linux/random.h` refers to types
defined in `linux/types.h`, but fails to `#include` it. So, we include
it ourselves.