### PR TITLE
ASN1: Set most-significant-BIT (not byte) to 0 in INTEGER

### DIFF
--- a/src/internal/asn1.c
+++ b/src/internal/asn1.c
@@ -243,7 +243,7 @@ build_serial_number(unsigned char **current_loc)
     assert(len == 20);
     // Nb. We're only generating 19 bytes of randomness
     xtt_crypto_get_random(*current_loc, len-1);
-    (*current_loc)[0] = 0x00;   // clear MSB, to ensure it's not a signed integer
+    (*current_loc)[0] &= 0x7F;   // clear msb, to ensure it's positive 
 
     *current_loc += len;
 }


### PR DESCRIPTION
ASN.1 DER type INTEGER (which we use for serial number in certificate) is expected to be:
- A positive number, with the most-significant bit equal to 0
- A twos-complement negative number, with the most-significant bit equal to 1
- A positive number, with the most-significant BYTE equal to 0, and the 9th-most-significant bit equal to 1

We were forcing the most-significant byte to 0, which indicates that the 9th-bit would be 1, but we weren't demanding that. This caused problems with some parsers.

The fix is to set just the most-significant-BIT to 0.