### PR TITLE
cmake: explicitly set language as C

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 list(APPEND CMAKE_MODULE_PATH CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
 
 project(xtt
+        LANGUAGES C
         VERSION "0.8.1"
         )
 


### PR DESCRIPTION
Otherwise CMake looks for both C and C++ compilers, but some embedded environments may not have a C++ compiler available.