### PR TITLE
Allow the client to read everything from TPM, and require no external files

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,13 +129,11 @@ into the working directory:
 cp ${xtt_root_directory}/examples/data/client/* .
 ```
 
-The client executable takes the `xtt_suite_spec` to use
-(run the executable with no arguments to see what the options are)
-and the IP and port of the server as parameters:
+The client executable can take the IP and port of the server as parameters
+(run `xtt_client -h` for a full help on all available parameters):
 ```bash
-xtt_client 1 127.0.0.1 4444
+xtt_client -a 127.0.0.1 -p 4444
 ```
-(a suite_spec value of `1` indicates `XTT_X25519_LRSW_ED25519_CHACHA20POLY1305_SHA512`).
 
 The client will then initiate an identity-provisioning handshake with the server
 listening on the given IP and port,

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -14,12 +14,6 @@
 
 cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 
-option(EXAMPLES_USE_TCP_TPM "use a TCP-socket-based TPM TCTI in the example client" OFF)
-
-if(USE_TPM_TCP)
-        add_definitions(-DUSE_TPM_TCP)
-endif()
-
 set(XTT_CURRENT_PROGRAMS_BINARY_DIR ${CMAKE_BINARY_DIR}/bin/)
 
 set(XTT_EXAMPLES_MAIN_FILES
@@ -28,7 +22,6 @@ set(XTT_EXAMPLES_MAIN_FILES
         xtt_generate_certificate.c
         xtt_server.c
         )
-
 
 foreach(main_file ${XTT_EXAMPLES_MAIN_FILES})
         get_filename_component(program_name ${main_file} NAME_WE)

--- a/examples/xtt_client.c
+++ b/examples/xtt_client.c
@@ -28,14 +28,15 @@
 #include <sys/socket.h>
 #include <arpa/inet.h>
 #include <unistd.h>
+#include <getopt.h>
+
+#define MAX_SERVER_IP_LENGTH 16
+#define MAX_TPM_DEV_FILE_LENGTH 128
 
 #ifdef USE_TPM
 #include <tss2/tss2_sys.h>
-#ifdef USE_TPM_TCP
 #include <tss2/tss2_tcti_socket.h>
-#else
 #include <tss2/tss2_tcti_device.h>
-#endif
 unsigned char tcti_context_buffer_g[256];
 #endif
 
@@ -49,7 +50,6 @@ uint32_t basename_handle_g = 0x1410007;
 uint32_t server_id_handle_g = 0x1410008;
 const char *tpm_hostname_g = "localhost";
 const char *tpm_port_g = "2321";
-const char *tpm_devfile_g = "/dev/tpm0";
 const size_t tpm_devfile_length_g = 9;
 const char *tpm_password = NULL;
 uint16_t tpm_password_len = 0;
@@ -76,17 +76,24 @@ typedef struct {
 certificate_db_record certificate_db[1];
 const size_t certificate_db_size = 1;
 
-void parse_cmd_args(int argc, char *argv[], xtt_suite_spec *suite_spec, char *ip, unsigned short *port, int *use_tpm);
+typedef enum {
+    XTT_TCTI_SOCKET,
+    XTT_TCTI_DEVICE,
+} xtt_tcti_type;
+
+void parse_cmd_args(int argc, char *argv[], xtt_suite_spec *suite_spec, char *ip,
+        unsigned short *port, int *use_tpm, xtt_tcti_type *tcti_type, char *dev_file);
 
 int connect_to_server(const char *ip, unsigned short port);
 
-int initialize_ids(xtt_identity_type *requested_client_id,
-                   xtt_identity_type *intended_server_id,
-                   int use_tpm);
+int initialize_server_id(xtt_identity_type *intended_server_id,
+                         int use_tpm,
+                         xtt_tcti_type tcti_type,
+                         const char* dev_file);
 
 int initialize_certs(int use_tpm);
 
-int initialize_daa(struct xtt_client_group_context *group_ctx, int use_tpm);
+int initialize_daa(struct xtt_client_group_context *group_ctx, int use_tpm, xtt_tcti_type tcti_type, const char* dev_file);
 
 #ifdef USE_TPM
 int
@@ -123,14 +130,16 @@ int main(int argc, char *argv[])
 
     // 0) Parse the command line args
     xtt_suite_spec suite_spec;
-    char server_ip[16];
+    char server_ip[MAX_SERVER_IP_LENGTH];
     unsigned short server_port;
     int use_tpm;
-    parse_cmd_args(argc, argv, &suite_spec, server_ip, &server_port, &use_tpm);
+    xtt_tcti_type tcti_type;
+    char tcti_dev_file[MAX_TPM_DEV_FILE_LENGTH];
+    parse_cmd_args(argc, argv, &suite_spec, server_ip, &server_port, &use_tpm, &tcti_type, tcti_dev_file);
 
     // 1) Setup the needed XTT contexts (from files).
     struct xtt_client_group_context group_ctx;
-    init_daa_ret = initialize_daa(&group_ctx, use_tpm);
+    init_daa_ret = initialize_daa(&group_ctx, use_tpm, tcti_type, tcti_dev_file);
     ret = init_daa_ret;
     if (0 != init_daa_ret) {
         fprintf(stderr, "Error initializing DAA context\n");
@@ -145,7 +154,7 @@ int main(int argc, char *argv[])
     // 2) Set my requested id and the intended server id.
     xtt_identity_type requested_client_id;
     xtt_identity_type intended_server_id;
-    ret = initialize_ids(&requested_client_id, &intended_server_id, use_tpm);
+    ret = initialize_server_id(&intended_server_id, use_tpm, tcti_type, tcti_dev_file);
     if(0 != ret) {
         fprintf(stderr, "Error setting XTT ID's!\n");
         goto finish;
@@ -206,34 +215,91 @@ finish:
     }
 }
 
-void parse_cmd_args(int argc, char *argv[], xtt_suite_spec *suite_spec, char *ip, unsigned short *port, int *use_tpm)
+void parse_cmd_args(int argc, char *argv[], xtt_suite_spec *suite_spec,
+        char *ip, unsigned short *port, int *use_tpm, xtt_tcti_type *tcti_type, char *dev_file)
 {
-    if (5 != argc && 4 != argc) {
-        fprintf(stderr, "usage: %s <suite_spec> <server IP> <server port> [--use-tpm]\n", argv[0]);
-        fprintf(stderr, "\twhere:\n");
-        fprintf(stderr, "\t\tXTT_X25519_LRSW_ED25519_CHACHA20POLY1305_SHA512    = 1,\n");
-        fprintf(stderr, "\t\tXTT_X25519_LRSW_ED25519_CHACHA20POLY1305_BLAKE2B   = 2,\n");
-        fprintf(stderr, "\t\tXTT_X25519_LRSW_ED25519_AES256GCM_SHA512           = 3,\n");
-        fprintf(stderr, "\t\tXTT_X25519_LRSW_ED25519_AES256GCM_BLAKE2B          = 4,\n");
-        exit(1);
-    }
 
-    *suite_spec = atoi(argv[1]);
-    if (*suite_spec != 1 && *suite_spec != 2 && *suite_spec != 3 && *suite_spec != 4) {
-        fprintf(stderr, "Unknown suite_spec\n");
-        exit(1);
-    }
-
-    strcpy(ip, argv[2]);
-    *port = atoi(argv[3]);
-
+    // Set defaults
+    *suite_spec = XTT_X25519_LRSW_ED25519_CHACHA20POLY1305_SHA512;
+    strcpy(ip, "127.0.0.1");
+    *port = 4444;
     *use_tpm = 0;
-    if (5 == argc) {
-        if (0 == strcmp("--use-tpm", argv[4])) {
-            *use_tpm = 1;
-        } else {
-            fprintf(stderr, "Unknown tpm option: %s\n", argv[4]);
-            exit(1);
+    *tcti_type = XTT_TCTI_DEVICE;
+    strcpy(dev_file, "/dev/tpm0");
+
+    // Parse args
+    int c;
+    while ((c = getopt(argc, argv, "ms:a:p:t:d:h")) != -1) {
+        switch (c) {
+            case 'm':
+                *use_tpm = 1;
+                break;
+            case 's':
+                if (0 == strcmp(optarg, "X25519_LRSW_ED25519_CHACHA20POLY1305_SHA512")) {
+                    *suite_spec = XTT_X25519_LRSW_ED25519_CHACHA20POLY1305_SHA512;
+                } else if (0 == strcmp(optarg, "X25519_LRSW_ED25519_CHACHA20POLY1305_BLAKE2B")) {
+                    *suite_spec = XTT_X25519_LRSW_ED25519_CHACHA20POLY1305_BLAKE2B;
+                } else if (0 == strcmp(optarg, "X25519_LRSW_ED25519_AES256GCM_SHA512")) {
+                    *suite_spec = XTT_X25519_LRSW_ED25519_AES256GCM_SHA512;
+                } else if (0 == strcmp(optarg, "X25519_LRSW_ED25519_AES256GCM_BLAKE2B")) {
+                    *suite_spec = XTT_X25519_LRSW_ED25519_AES256GCM_BLAKE2B;
+                } else {
+                    fprintf(stderr, "Unknown suite_spec '%s'\n", optarg);
+                    exit(1);
+                }
+                break;
+            case 'a':
+            {
+                size_t ip_opt_len = strlen(optarg);
+                if (ip_opt_len > MAX_SERVER_IP_LENGTH) {
+                    fprintf(stderr, "Provided server IP address is too long (> %d)\n", MAX_SERVER_IP_LENGTH);
+                    exit(1);
+                }
+                strncpy(ip, optarg, MAX_SERVER_IP_LENGTH-1);
+                break;
+            }
+            case 'p':
+                *port = atoi(optarg);
+                break;
+            case 't':
+                if (0 == strcmp(optarg, "device")) {
+                    *tcti_type = XTT_TCTI_DEVICE;
+                } else if (0 == strcmp(optarg, "socket")) {
+                    *tcti_type = XTT_TCTI_SOCKET;
+                } else {
+                    fprintf(stderr, "Unknown tcti_type '%s'\n", optarg);
+                    exit(1);
+                }
+                break;
+            case 'd':
+            {
+                size_t dev_opt_len = strlen(optarg);
+                if (dev_opt_len > MAX_TPM_DEV_FILE_LENGTH) {
+                    fprintf(stderr, "Provided TPM TCTI device file is too long (> %d)\n", MAX_TPM_DEV_FILE_LENGTH);
+                    exit(1);
+                }
+                strncpy(dev_file, optarg, MAX_TPM_DEV_FILE_LENGTH-1);
+                break;
+            }
+            case 'h':
+                fprintf(stderr, "usage: %s [-m] [-s <suite_spec>] [-a <server_ip>] [-p <server_port>] [-t <tcti_type>] [-d <tcti_device_file>]\n", argv[0]);
+                fprintf(stderr, "\tsuite_spec can be one of the following:\n");
+                fprintf(stderr, "\t\tX25519_LRSW_ED25519_CHACHA20POLY1305_SHA512 (default)\n");
+                fprintf(stderr, "\t\tX25519_LRSW_ED25519_CHACHA20POLY1305_BLAKE2B\n");
+                fprintf(stderr, "\t\tX25519_LRSW_ED25519_AES256GCM_SHA512\n");
+                fprintf(stderr, "\t\tX25519_LRSW_ED25519_AES256GCM_BLAKE2B\n");
+                fprintf(stderr, "\tserver_ip is the dotted-decimal address of the XTT server to connect to\n");
+                fprintf(stderr, "\t\t127.0.0.1 (default)\n");
+                fprintf(stderr, "\tserver_port is the TCP port of the XTT server to connect to\n");
+                fprintf(stderr, "\t\t4444 (default)\n");
+                fprintf(stderr, "\t-m indicates to use a TPM, not local files\n");
+                fprintf(stderr, "\tThe following options are ignored unless -m is specified:\n");
+                fprintf(stderr, "\t\ttcti_type can be one of the following:\n");
+                fprintf(stderr, "\t\t\tdevice (default)\n");
+                fprintf(stderr, "\t\t\tsocket\n");
+                fprintf(stderr, "\t\ttcti_device_file is ignored unless tcti_type==device\n");
+                fprintf(stderr, "\t\t\t/dev/tpm0 (default)\n");
+                exit(1);
         }
     }
 }
@@ -260,28 +326,11 @@ int connect_to_server(const char *ip, unsigned short port)
     return sock_ret;
 }
 
-int initialize_ids(xtt_identity_type *requested_client_id,
-                   xtt_identity_type *intended_server_id,
-                   int use_tpm)
+int initialize_server_id(xtt_identity_type *intended_server_id,
+                         int use_tpm,
+                         xtt_tcti_type tcti_type,
+                         const char* dev_file)
 {
-#ifdef USE_TPM
-    TSS2_TCTI_CONTEXT *tcti_context;
-    if (use_tpm) {
-        tcti_context = (TSS2_TCTI_CONTEXT*)tcti_context_buffer_g;
-#ifdef USE_TPM_TCP
-        assert(tss2_tcti_getsize_socket() < sizeof(tcti_context_buffer_g));
-        int tcti_ret = tss2_tcti_init_socket(tpm_hostname_g, tpm_port_g, tcti_context);
-#else
-        assert(tss2_tcti_getsize_device() < sizeof(tcti_context_buffer_g));
-        int tcti_ret = tss2_tcti_init_device(tpm_devfile_g, tpm_devfile_length_g, tcti_context);
-#endif
-        if (TSS2_RC_SUCCESS != tcti_ret) {
-            fprintf(stderr, "Error: Unable to initialize TCTI context\n");
-            return -1;
-        }
-    }
-#endif
-
     int read_ret;
 
     // 1) Set requested client id from file
@@ -297,8 +346,27 @@ int initialize_ids(xtt_identity_type *requested_client_id,
         memcpy(requested_client_id->data, requested_client_id_str, sizeof(xtt_identity_type));
     }
 
-    // Set server's id from file
+    // Set server's id from file/NVRAM
     if (use_tpm) {
+#ifdef USE_TPM
+        TSS2_TCTI_CONTEXT *tcti_context = (TSS2_TCTI_CONTEXT*)tcti_context_buffer_g;
+        switch (tcti_type) {
+            case XTT_TCTI_SOCKET:
+                assert(tss2_tcti_getsize_socket() < sizeof(tcti_context_buffer_g));
+                if (TSS2_RC_SUCCESS != tss2_tcti_init_socket(tpm_hostname_g, tpm_port_g, tcti_context)) {
+                    fprintf(stderr, "Error: Unable to initialize socket TCTI context\n");
+                    return -1;
+                }
+                break;
+            case XTT_TCTI_DEVICE:
+                assert(tss2_tcti_getsize_device() < sizeof(tcti_context_buffer_g));
+                if (TSS2_RC_SUCCESS != tss2_tcti_init_device(dev_file, strlen(dev_file), tcti_context)) {
+                    fprintf(stderr, "Error: Unable to initialize device TCTI context\n");
+                    return -1;
+                }
+                break;
+        }
+
         int nvram_ret;
         nvram_ret = read_nvram(intended_server_id->data,
                                sizeof(xtt_identity_type),
@@ -308,6 +376,10 @@ int initialize_ids(xtt_identity_type *requested_client_id,
             fprintf(stderr, "Error reading server id from TPM NVRAM");
             return -1;
         }
+#else
+        fprintf(stderr, "Attempted to use a TPM, but not built with TPM enabled!\n");
+        return -1;
+#endif
     } else {
         read_ret = read_file_into_buffer(intended_server_id->data, sizeof(xtt_identity_type), server_id_file);
         if (sizeof(xtt_identity_type) != read_ret) {
@@ -319,7 +391,7 @@ int initialize_ids(xtt_identity_type *requested_client_id,
     return 0;
 }
 
-int initialize_daa(struct xtt_client_group_context *group_ctx, int use_tpm)
+int initialize_daa(struct xtt_client_group_context *group_ctx, int use_tpm, xtt_tcti_type tcti_type, const char* dev_file)
 {
     (void)write_buffer_to_file;
     xtt_return_code_type rc;
@@ -329,16 +401,20 @@ int initialize_daa(struct xtt_client_group_context *group_ctx, int use_tpm)
     TSS2_TCTI_CONTEXT *tcti_context;
     if (use_tpm) {
         tcti_context = (TSS2_TCTI_CONTEXT*)tcti_context_buffer_g;
-#ifdef USE_TPM_TCP
-        assert(tss2_tcti_getsize_socket() < sizeof(tcti_context_buffer_g));
-        int tcti_ret = tss2_tcti_init_socket(tpm_hostname_g, tpm_port_g, tcti_context);
-#else
-        assert(tss2_tcti_getsize_device() < sizeof(tcti_context_buffer_g));
-        int tcti_ret = tss2_tcti_init_device(tpm_devfile_g, tpm_devfile_length_g, tcti_context);
-#endif
-        if (TSS2_RC_SUCCESS != tcti_ret) {
-            fprintf(stderr, "Error: Unable to initialize TCTI context\n");
-            return -1;
+        switch (tcti_type) {
+            case XTT_TCTI_SOCKET:
+                assert(tss2_tcti_getsize_socket() < sizeof(tcti_context_buffer_g));
+                if (TSS2_RC_SUCCESS != tss2_tcti_init_socket(tpm_hostname_g, tpm_port_g, tcti_context)) {
+                    fprintf(stderr, "Error: Unable to initialize socket TCTI context\n");
+                    return -1;
+                }
+                break;
+            case XTT_TCTI_DEVICE:
+                assert(tss2_tcti_getsize_device() < sizeof(tcti_context_buffer_g));
+                if (TSS2_RC_SUCCESS != tss2_tcti_init_device(dev_file, strlen(dev_file), tcti_context)) {
+                    fprintf(stderr, "Error: Unable to initialize device TCTI context\n");
+                    return -1;
+                }
         }
     }
 #endif


### PR DESCRIPTION
This series updates the `xtt_client` example in the following ways:
- Uses the most-recent changes to `xdaa-issuer`'s issuing of basename and server_id to TPM, in order to read these data from the TPM, rather than from file
- Converts CLI parameter parsing from hand-rolled to using `getopts`
- The `getopts` param handling now allows the TPM TCTI device file to be set from the CLI (and thus this PR fixes #37)
- The `getopts` param handling also allows setting the requested client ID from the CLI, not from file (and the default is to use `null_id`)

Nb. If not using a TPM, files are of course still required, and their locations are still hard-coded in the executable. Also, this does not update the `xtt_server` in similar ways.
