### PR TITLE
Fix invalid random function casts in ecdaa wrapper

### DIFF
--- a/examples/xtt_server.c
+++ b/examples/xtt_server.c
@@ -443,12 +443,7 @@ assign_client_id(xtt_identity_type *assigned_client_id_out,
     // If the client sent xtt_null_client_id assign them a randomly-generated id.
     // Otherwise, just echo back what they requested.
     if (0 == xtt_crypto_memcmp(requested_client_id->data, xtt_null_identity.data, sizeof(xtt_identity_type))) {
-        if (0 != xtt_crypto_get_random(assigned_client_id_out->data, sizeof(xtt_identity_type))) {
-            fprintf(stderr, "Client requested an id assignment, but there was an error generating it!\n");
-            return -1;
-            // close(client_sock);
-            // goto finished_handshake;
-        }
+        xtt_crypto_get_random(assigned_client_id_out->data, sizeof(xtt_identity_type));
     } else {
         memcpy(assigned_client_id_out->data, requested_client_id->data, sizeof(xtt_identity_type));
     }

--- a/include/xtt/crypto_wrapper.h
+++ b/include/xtt/crypto_wrapper.h
@@ -1,13 +1,13 @@
 /******************************************************************************
  *
  * Copyright 2018 Xaptum, Inc.
- * 
+ *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
  *    You may obtain a copy of the License at
- * 
+ *
  *        http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  *    Unless required by applicable law or agreed to in writing, software
  *    distributed under the License is distributed on an "AS IS" BASIS,
  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -32,7 +32,7 @@ int xtt_crypto_memcmp(const unsigned char *one, const unsigned char *two, uint16
 
 void xtt_crypto_secure_clear(unsigned char* memory, uint16_t memory_length);
 
-int xtt_crypto_get_random(unsigned char* buffer, uint16_t buffer_length);
+void xtt_crypto_get_random(unsigned char* buffer, uint16_t buffer_length);
 
 int xtt_crypto_create_x25519_key_pair(xtt_x25519_pub_key *pub, xtt_x25519_priv_key *priv);
 

--- a/src/ecdaa_wrapper.c
+++ b/src/ecdaa_wrapper.c
@@ -28,6 +28,20 @@
 #include <assert.h>
 #include <string.h>
 
+/*
+ * Wrap our rand function, to make the signatures agree.
+ */
+static
+void rand_wrapper(void *buf, size_t buflen)
+{
+    if (buflen > UINT16_MAX) {
+        assert(buflen <= UINT16_MAX);
+        return;
+    }
+
+    xtt_crypto_get_random(buf, buflen);
+}
+
 #ifdef USE_TPM
 int
 xtt_daa_sign_lrswTPM(unsigned char *signature_out,
@@ -70,7 +84,7 @@ xtt_daa_sign_lrswTPM(unsigned char *signature_out,
                                            basename,
                                            basename_len,
                                            &ecdaa_cred,
-                                           (ecdaa_rand_func)xtt_crypto_get_random,
+                                           rand_wrapper,
                                            &ecdaa_tpm_context);
     if (0 != ret) {
         return -1;
@@ -120,7 +134,7 @@ xtt_daa_sign_lrsw(unsigned char *signature_out,
                                        basename_len,
                                        &ecdaa_secret_key,
                                        &ecdaa_cred,
-                                       (ecdaa_rand_func)xtt_crypto_get_random);
+                                       rand_wrapper);
     if (0 != ret) {
         return -1;
     }

--- a/src/ecdaa_wrapper.c
+++ b/src/ecdaa_wrapper.c
@@ -34,6 +34,7 @@
 static
 void rand_wrapper(void *buf, size_t buflen)
 {
+    // ECDAA always requests <256B, so size_t->uint16_t conversion _should_ be OK.
     if (buflen > UINT16_MAX) {
         assert(buflen <= UINT16_MAX);
         return;

--- a/src/ecdaa_wrapper.c
+++ b/src/ecdaa_wrapper.c
@@ -1,13 +1,13 @@
 /******************************************************************************
  *
  * Copyright 2018 Xaptum, Inc.
- * 
+ *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
  *    You may obtain a copy of the License at
- * 
+ *
  *        http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  *    Unless required by applicable law or agreed to in writing, software
  *    distributed under the License is distributed on an "AS IS" BASIS,
  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/libsodium_wrapper.c
+++ b/src/libsodium_wrapper.c
@@ -73,11 +73,12 @@ void xtt_crypto_secure_clear(unsigned char* memory, uint16_t memory_length)
     sodium_memzero(memory, memory_length);
 }
 
-int xtt_crypto_get_random(unsigned char* buffer, uint16_t buffer_length)
+void xtt_crypto_get_random(unsigned char* buffer, uint16_t buffer_length)
 {
+    // Libsodium makes sure any requests (of any length) always succeed
+    // (i.e. they handle EAGAIN or EINTR for getrandom).
+    // If there is a fatal problem, they die loudly.
     randombytes_buf(buffer, buffer_length);
-    
-    return 0;
 }
 
 int xtt_crypto_create_x25519_key_pair(xtt_x25519_pub_key *pub, xtt_x25519_priv_key *priv)

--- a/src/libsodium_wrapper.c
+++ b/src/libsodium_wrapper.c
@@ -1,13 +1,13 @@
 /******************************************************************************
  *
  * Copyright 2018 Xaptum, Inc.
- * 
+ *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
  *    You may obtain a copy of the License at
- * 
+ *
  *        http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  *    Unless required by applicable law or agreed to in writing, software
  *    distributed under the License is distributed on an "AS IS" BASIS,
  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.


### PR DESCRIPTION
Rather than cast the `xtt_crypto_get_random` function to the type `ecdaa_rand_func`, create a wrapper function to ensure the signatures are the same and handle any possible conversion problems.

As part of this change, we're also no longer returning `int` from `xtt_crypto_get_random`, and instead returning `void`. The function that `xtt_crypto_get_random` wraps returns `void` anyhow, so this return type is misleading and shouldn't be checked (which it, largely, wasn't in the existing  code).

Fixes #42 