### PR TITLE
Fixing ECDSA for CPP

### DIFF
--- a/include/xtt/crypto_wrapper.h
+++ b/include/xtt/crypto_wrapper.h
@@ -20,12 +20,11 @@
 #define XTT_CRYPTO_WRAPPER_H
 #pragma once
 
-#include <amcl/ecdh_NIST256.h>
-#include <xtt/crypto_types.h>
-
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#include <xtt/crypto_types.h>
 
 int xtt_crypto_initialize_crypto();
 

--- a/src/internal/crypto_utils.c
+++ b/src/internal/crypto_utils.c
@@ -301,7 +301,6 @@ int verify_root_ecdsap256(const unsigned char *signature, //equivalent to verify
                                         xtt_server_certificate_length_uptosignature_fromsignaturetype(XTT_SERVER_SIGNATURE_TYPE_ECDSAP256),
                                         &self->public_key.ecdsap256);
     if (0 != ret) {
-        printf("\n%d\n", ret);
         return XTT_RETURN_BAD_ROOT_SIGNATURE;
     } else {
         return XTT_RETURN_SUCCESS;

--- a/test/certificate_test.c
+++ b/test/certificate_test.c
@@ -17,7 +17,6 @@
  *****************************************************************************/
 
 #include <xtt.h>
-#include <amcl/x509.h>
 #include <assert.h>
 #include "test-utils.h"
 #include "../src/internal/asn1.h"

--- a/test/wrapper_sanity-test.c
+++ b/test/wrapper_sanity-test.c
@@ -17,7 +17,7 @@
  *****************************************************************************/
 
 #include <xtt.h>
-
+#include <amcl/ecdh_NIST256.h>
 #include "test-utils.h"
 
 #include <string.h>


### PR DESCRIPTION
Removed #include's related to AMCL from public API since AMCL uses macros that are exclusive to C. When we try to compile in C++, the macros are undefined. However, we can get around this by only using AMCL in the XTT library that is compiled in C. 