### PR TITLE
Client: Use DNS for server hostname

### DIFF
--- a/examples/xtt_client.c
+++ b/examples/xtt_client.c
@@ -128,6 +128,8 @@ int main(int argc, char *argv[])
         return 1;
     }
 
+    setbuf(stdout, NULL);
+
     int init_daa_ret = -1;
     int socket = -1;
 

--- a/examples/xtt_client.c
+++ b/examples/xtt_client.c
@@ -696,7 +696,7 @@ int do_handshake(int socket,
                 fprintf(stderr, "Received error message from server\n");
                 return -1;
             default:
-                printf("Encountered error during client handshake: %d\n", rc);
+                printf("Encountered error during client handshake: %s (%d)\n", xtt_strerror(rc), rc);
                 unsigned char err_buffer[16];
                 (void)xtt_client_build_error_msg(&bytes_requested, &io_ptr, ctx);
                 int write_ret = write(socket, err_buffer, bytes_requested);


### PR DESCRIPTION
This PR add the following to the `xtt_client`:
- Use `xtt_strerror` for printing errors to stdout
- Use `getaddrinfo` for DNS-resolution of server hostnames in
- Don't buffer `stdout` output, so regular output doesn't come out after the `stderr` reporting