### PR TITLE
Examples: Include basename in GID computation

### DIFF
--- a/examples/xtt_client.c
+++ b/examples/xtt_client.c
@@ -510,9 +510,19 @@ int initialize_daa(struct xtt_client_group_context *group_ctx, int use_tpm, TSS2
         }
     }
 
-    // 2) Generate gid from gpk (gid = SHA-256(gpk))
+    // 2) Generate gid from gpk (gid = SHA-256(gpk | basename))
     xtt_group_id gid;
-    int hash_ret = crypto_hash_sha256(gid.data, gpk.data, sizeof(gpk));
+    crypto_hash_sha256_state hash_state;
+    int hash_ret = crypto_hash_sha256_init(&hash_state);
+    if (0 != hash_ret)
+        return -1;
+    hash_ret = crypto_hash_sha256_update(&hash_state, gpk.data, sizeof(gpk));
+    if (0 != hash_ret)
+        return -1;
+    hash_ret = crypto_hash_sha256_update(&hash_state, basename, basename_len);
+    if (0 != hash_ret)
+        return -1;
+    hash_ret = crypto_hash_sha256_final(&hash_state, gid.data);
     if (0 != hash_ret)
         return -1;
 

--- a/examples/xtt_server.c
+++ b/examples/xtt_server.c
@@ -159,8 +159,18 @@ int initialize(struct xtt_server_certificate_context *cert_ctx,
     if (XTT_RETURN_SUCCESS != rc)
         return -1;
 
-    // 4) Generate GID from GPK (GID = SHA-256(GPK))
-    int hash_ret = crypto_hash_sha256(gpk_db[0].gid.data, gpk.data, sizeof(gpk));
+    // 4) Generate GID from GPK (GID = SHA-256(GPK | basename))
+    crypto_hash_sha256_state hash_state;
+    int hash_ret = crypto_hash_sha256_init(&hash_state);
+    if (0 != hash_ret)
+        return -1;
+    hash_ret = crypto_hash_sha256_update(&hash_state, gpk.data, sizeof(gpk));
+    if (0 != hash_ret)
+        return -1;
+    hash_ret = crypto_hash_sha256_update(&hash_state, basename, basename_len);
+    if (0 != hash_ret)
+        return -1;
+    hash_ret = crypto_hash_sha256_final(&hash_state, gpk_db[0].gid.data);
     if (0 != hash_ret)
         return -1;
 


### PR DESCRIPTION
In the example client and server, define the GID to be SHA-256(GPK | basename), rather than just of the GPK.