### PR TITLE
Put common name in IPv6 formatting

### DIFF
--- a/include/xtt/crypto_types.h
+++ b/include/xtt/crypto_types.h
@@ -68,7 +68,7 @@ typedef struct {unsigned char data[32];} xtt_signing_nonce;
 typedef struct {unsigned char data[8];} xtt_session_id_seed;
 typedef struct {unsigned char data[16];} xtt_session_id;
 typedef struct {unsigned char data[16];} xtt_identity_type;
-typedef struct {char data[33];} xtt_identity_string;
+typedef struct {char data[40];} xtt_identity_string;
 extern const xtt_identity_type xtt_null_identity;
 typedef struct {unsigned char data[130];} xtt_server_cookie;
 

--- a/include/xtt/util/asn1.h
+++ b/include/xtt/util/asn1.h
@@ -28,7 +28,7 @@
 extern "C" {
 #endif
 
-#define XTT_X509_CERTIFICATE_LENGTH 333
+#define XTT_X509_CERTIFICATE_LENGTH 348
 size_t xtt_x509_certificate_length(void);
 
 #define XTT_ASN1_PRIVATE_KEY_LENGTH 121

--- a/src/crypto_types.c
+++ b/src/crypto_types.c
@@ -1,13 +1,13 @@
 /******************************************************************************
  *
  * Copyright 2018 Xaptum, Inc.
- * 
+ *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
  *    You may obtain a copy of the License at
- * 
+ *
  *        http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  *    Unless required by applicable law or agreed to in writing, software
  *    distributed under the License is distributed on an "AS IS" BASIS,
  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -29,13 +29,22 @@ xtt_identity_to_string(const xtt_identity_type *identity_in,
                        xtt_identity_string *string_out)
 {
     char *ptr = string_out->data;
-
-    for (size_t i=0; i<sizeof(xtt_identity_type); ++i) {
-        int encode_ret = sprintf(ptr, "%02X", identity_in->data[i]);
-        if (encode_ret != 2) {
-            return -1;
+    int k = 0;
+    for (size_t i=0; i<sizeof(xtt_identity_type)+7; ++i) {
+        if(0 == (i+1)%3){
+            int encode_ret = sprintf(ptr, ":");
+            if (encode_ret != 1) {
+                return -1;
+            }
+            ptr ++;
+        } else {
+            int encode_ret = sprintf(ptr, "%02X", identity_in->data[k]);
+            if (encode_ret != 2) {
+                return -1;
+            }
+            ptr += 2;
+            k++;
         }
-        ptr += 2;
     }
 
     string_out->data[sizeof(xtt_identity_string)-1] = 0;

--- a/src/util/internal/asn1.c
+++ b/src/util/internal/asn1.c
@@ -166,7 +166,7 @@ build_tbs_certificate(unsigned char **current_loc,
                       const char *common_name)
 {
     set_as_sequence(current_loc);
-    set_length(current_loc, tbs_certificate_length - 1 - 2);
+    set_length(current_loc, tbs_certificate_length - 1 - 3);
 
     build_serial_number(current_loc);
 

--- a/src/util/internal/asn1.h
+++ b/src/util/internal/asn1.h
@@ -49,7 +49,7 @@ extern const unsigned char UTF8STRING_ATTRTYPE;
 extern const int VALIDITY_YEARS;
 
 enum { UTC_LENGTH = 13 };                                                               // YYMMDDhhssmm'Z'
-enum { NAME_LENGTH = 32 };
+enum { NAME_LENGTH = 39 };
 enum { RAW_PRIVATE_KEY_LENGTH = 32 };
 enum { PUBLIC_KEY_LENGTH = 65 };
 enum { SIGNATURE_LENGTH = 64 };
@@ -77,7 +77,7 @@ enum { curve_def_length = 1 + 1 + prime256v1_oid_length + ecpublickey_oid_length
 enum { pubkey_bitstring_length = 1 + 1 + 1 + PUBLIC_KEY_LENGTH };                       // tag(1) + length(1) + padding(1) + content(65)
 enum { subjectpublickeyinfo_length = 1 + 1 + curve_def_length + pubkey_bitstring_length };    // tag(1) + length(1) + ecdsa_algid_length + pubkey_bitstring_length
 
-enum { tbs_certificate_length = 1 + 2 + serial_num_length + ecdsap256_algid_length + name_length + validity_length + name_length + subjectpublickeyinfo_length};
+enum { tbs_certificate_length = 1 + 3 + serial_num_length + ecdsap256_algid_length + name_length + validity_length + name_length + subjectpublickeyinfo_length};
 
 enum { signature_algorithm_length = ecdsap256_algid_length };
 


### PR DESCRIPTION
Fixes #55 by inserting `:` every 4 characters. While not a true IPv6 format, much more readable than a string of hex digits.