### PR TITLE
Add tool capability to parse certificates

### DIFF
--- a/include/xtt/util/util_errors.h
+++ b/include/xtt/util/util_errors.h
@@ -2,11 +2,14 @@
 #define XTT_UTIL_ERRORS_H
 #pragma once
 
+#define SUCCESS 0
 #define SAVE_TO_FILE_ERROR -1
 #define READ_FROM_FILE_ERROR -2
 #define KEY_CREATION_ERROR -3
 #define CERT_CREATION_ERROR -4
 #define ASN1_CREATION_ERROR -5
 #define EXPIRY_PASSED -6
+#define PARSE_CERT_ERROR -7
+#define VOID_SUCCESS -8
 
 #endif

--- a/src/util/file_io.c
+++ b/src/util/file_io.c
@@ -62,6 +62,12 @@ cleanup:
         goto cleanup;
      }
 
+     fgetc(file_ptr);
+     if(!feof(file_ptr)){
+         ret = READ_FROM_FILE_ERROR;
+         goto cleanup;
+     }
+
      ret = (int)bytes_read;
 
 cleanup:

--- a/tool/CMakeLists.txt
+++ b/tool/CMakeLists.txt
@@ -19,7 +19,8 @@ cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 ################################################################################
 SET(TOOL_SRCS
         xtt.c
-        parse_cli.c)
+        parse_cli.c
+        infocert.c)
 add_executable(xtt-tool ${TOOL_SRCS})
 set_target_properties(xtt-tool PROPERTIES OUTPUT_NAME xtt)
 if(BUILD_SHARED_LIBS)

--- a/tool/infocert.c
+++ b/tool/infocert.c
@@ -1,0 +1,108 @@
+/******************************************************************************
+ *
+ * Copyright 2018 Xaptum, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License
+ *
+ *****************************************************************************/
+#include "infocert.h"
+#include <xtt/crypto_types.h>
+#include <xtt/certificates.h>
+#include <xtt/util/asn1.h>
+#include <xtt/util/root.h>
+#include <xtt/util/util_errors.h>
+#include <xtt/util/file_io.h>
+#include <string.h>
+#include <stdio.h>
+
+struct xtt_server_certificate_raw_type;
+
+static
+void printf_hex(unsigned char* raw, size_t len)
+{
+    for (size_t i = 0; i < len; i++) {
+        printf("%02x", raw[i]);
+    }
+    printf("\n");
+}
+
+static
+void printf_char(unsigned char* raw, size_t len)
+{
+    for (size_t i = 0; i < len; i++) {
+        printf("%c", raw[i]);
+    }
+    printf("\n");
+}
+
+static
+void server_cert_out(struct xtt_server_certificate_raw_type* certificate)
+{
+    unsigned char* server_id = xtt_server_certificate_access_id(certificate);
+    printf("Server ID: ");
+    printf_hex(server_id, sizeof(xtt_identity_type));
+
+    unsigned char* expiry = xtt_server_certificate_access_expiry(certificate);
+    printf("Expiry: ");
+    printf_char(expiry, sizeof(xtt_certificate_expiry));
+
+    unsigned char* root_id = xtt_server_certificate_access_rootid(certificate);
+    printf("Root ID: ");
+    printf_hex(root_id, sizeof(xtt_certificate_root_id));
+
+    unsigned char* public_key = xtt_server_certificate_access_pubkey(certificate);
+    printf("Public Key: ");
+    printf_hex(public_key, sizeof(xtt_ecdsap256_pub_key));
+
+    return;
+}
+
+static
+void root_cert_out(xtt_root_certificate* root_certificate)
+{
+    xtt_certificate_root_id root_id;
+    xtt_ecdsap256_pub_key public_key;
+    xtt_deserialize_root_certificate(&public_key, &root_id, root_certificate);
+    printf("Root ID: ");
+    printf_hex(root_id.data, sizeof(xtt_certificate_root_id));
+
+    printf("Public key: ");
+    printf_hex(public_key.data, sizeof(xtt_ecdsap256_pub_key));
+    return;
+}
+
+
+int info_cert(const char* filename, enum infocert_type type)
+{
+    int read_ret = 0;
+
+    if (type == infocert_type_server) {
+        unsigned char certificate[XTT_SERVER_CERTIFICATE_ECDSAP256_LENGTH];
+        read_ret = xtt_read_from_file(filename, certificate, XTT_SERVER_CERTIFICATE_ECDSAP256_LENGTH);
+        if(read_ret != XTT_SERVER_CERTIFICATE_ECDSAP256_LENGTH) {
+            return READ_FROM_FILE_ERROR;
+        }
+        server_cert_out((struct xtt_server_certificate_raw_type*) certificate);
+    } else if (type == infocert_type_root) {
+        xtt_root_certificate root_certificate = {.data = {0}};
+        read_ret = xtt_read_from_file(filename, root_certificate.data, sizeof(xtt_certificate_root_id)+sizeof(xtt_ecdsap256_pub_key));
+        if(read_ret != sizeof(xtt_root_certificate)) {
+            return READ_FROM_FILE_ERROR;
+        }
+        root_cert_out(&root_certificate);
+    } else {
+        return PARSE_CERT_ERROR;
+    }
+
+    return VOID_SUCCESS;
+}

--- a/tool/infocert.h
+++ b/tool/infocert.h
@@ -16,47 +16,28 @@
  *
  *****************************************************************************/
 
-#ifndef PARSE_CLI_H
-#define PARSE_CLI_H
+#ifndef XTT_UTIL_INFO_CERT_H
+#define XTT_UTIL_INFO_CERT_H
 #pragma once
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#include <stdint.h>
-#include <getopt.h>
-#include <stdlib.h>
-#include <stdio.h>
-
-typedef enum {
-    action_genkey,
-    action_genx509cert,
-    action_wrapkeys,
-    action_genrootcert,
-    action_genservercert,
-    action_infocert,
-    action_help
-} action;
-
-struct cli_params {
-    action command;
-    const char* privkey;
-    const char* pubkey;
-    const char* id;
-    const char* cert;
-    const char* asn1;
-    const char* server_id;
-    const char* time;
-    const char* rootcert;
-    const char* rootpriv;
-    const char* servercert;
-    const char* serverpriv;
-    const char* serverpub;
-    const char* basename;
+enum infocert_type {
+    infocert_type_server,
+    infocert_type_root
 };
 
-void parse_cli(int argc, char **argv, struct cli_params *params);
+/*
+ * Parses certificate and prints important info to screen
+ *
+ * Returns:
+ * 0                        on success
+ * PARSE_CERT_ERROR         if infocert_type is not set
+ * READ_FROM_FILE_ERROR     error while reading in file
+*/
+int info_cert(const char* filename, enum infocert_type type);
 
 #ifdef __cplusplus
 }

--- a/tool/parse_cli.c
+++ b/tool/parse_cli.c
@@ -16,12 +16,9 @@
  *
  *****************************************************************************/
 
-#include <stdint.h>
 #include <getopt.h>
-#include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include <xtt.h>
 #include "parse_cli.h"
 
 static
@@ -271,6 +268,41 @@ void parse_genservercert_cli(int argc, char **argv, struct cli_params *params)
 
 }
 
+static
+void parse_infocert_cli(int argc, char** argv, struct cli_params *params){
+    params->rootcert = NULL;
+    params->servercert = NULL;
+    const char *usage_str = "Parse certificates and print out important information.\n\n"
+        "Usage: %s %s [-h] [-r <file>] [-s <file>]\n"
+        "\tOptions:\n"
+        "\t\t-h --help              Display this message.\n"
+        "\t\t-r --rootcert          Root certificate to be parsed\n"
+        "\t\t-s --servercert        Server certificate to be parsed\n"
+        ;
+
+    static struct option cli_options[] =
+    {
+        {"rootcert", required_argument, NULL, 'r'},
+        {"servercert", required_argument, NULL, 's'},
+        {"help", no_argument, NULL, 'h'},
+        {NULL, 0, NULL, 0}
+    };
+    int c;
+    while ((c = getopt_long(argc, argv, "r:s:h", cli_options, NULL)) != -1) {
+        switch (c) {
+            case 'r':
+                params->rootcert=optarg;
+                break;
+            case 's':
+                params->servercert=optarg;
+                break;
+            case 'h':
+                fprintf(stderr, usage_str, argv[0], argv[1]);
+                exit(1);
+        }
+    }
+}
+
 
 void parse_cli(int argc, char** argv, struct cli_params *params)
 {
@@ -282,6 +314,7 @@ void parse_cli(int argc, char** argv, struct cli_params *params)
         "\twrapkeys                 Generate ASN.1 wrapped keys.\n"
         "\tgenrootcert              Generate root certificate.\n"
         "\tgenservercert            Generate server certificate and server private key.\n"
+        "\tinfocert                 Get information about a certificate.\n"
         ;
 
     if(argc <=1 || strcmp(argv[1], "-h")==0 || strcmp(argv[1], "--help")==0) {
@@ -309,6 +342,10 @@ void parse_cli(int argc, char** argv, struct cli_params *params)
     {
         params->command=action_genservercert;
         parse_genservercert_cli(argc, argv, params);
+    } else if (strcmp(argv[1], "infocert")==0)
+    {
+        params->command=action_infocert;
+        parse_infocert_cli(argc, argv, params);
     } else
     {
         printf("'%s' is not an option for the XTT tool.\n", argv[1]);


### PR DESCRIPTION
`infocert` parses the certificate depending on what type we input. It takes the raw hex and prints out the important information to the screen-no files are created.