### PR TITLE
Change error messages to stderror

### DIFF
--- a/tool/parse_cli.c
+++ b/tool/parse_cli.c
@@ -51,7 +51,7 @@ void parse_genkey_cli(int argc, char **argv, struct cli_params *params)
                 params->pubkey=optarg;
                 break;
             case 'h':
-                fprintf(stderr, usage_str, argv[0], argv[1]);
+                printf(usage_str, argv[0], argv[1]);
                 exit(1);
         }
     }
@@ -101,7 +101,7 @@ void parse_genx509cert_cli(int argc, char **argv, struct cli_params *params)
                 params->cert = optarg;
                 break;
             case 'h':
-                fprintf(stderr, usage_str, argv[0], argv[1]);
+                printf(usage_str, argv[0], argv[1]);
                 exit(1);
         }
     }
@@ -145,7 +145,7 @@ void parse_wrapkeys_cli(int argc, char **argv, struct cli_params *params)
                 params->asn1 = optarg;
                 break;
             case 'h':
-                fprintf(stderr, usage_str, argv[0], argv[1]);
+                printf(usage_str, argv[0], argv[1]);
                 exit(1);
         }
     }
@@ -195,7 +195,7 @@ void parse_genroot_cli(int argc, char **argv, struct cli_params *params)
                 params->rootcert = optarg;
                 break;
             case 'h':
-                fprintf(stderr, usage_str, argv[0], argv[1]);
+                printf(usage_str, argv[0], argv[1]);
                 exit(1);
         }
     }
@@ -261,7 +261,7 @@ void parse_genservercert_cli(int argc, char **argv, struct cli_params *params)
                 params->servercert = optarg;
                 break;
             case 'h':
-                fprintf(stderr, usage_str, argv[0], argv[1]);
+                printf(usage_str, argv[0], argv[1]);
                 exit(1);
         }
     }
@@ -297,7 +297,7 @@ void parse_infocert_cli(int argc, char** argv, struct cli_params *params){
                 params->servercert=optarg;
                 break;
             case 'h':
-                fprintf(stderr, usage_str, argv[0], argv[1]);
+                printf(usage_str, argv[0], argv[1]);
                 exit(1);
         }
     }
@@ -318,7 +318,7 @@ void parse_cli(int argc, char** argv, struct cli_params *params)
         ;
 
     if(argc <=1 || strcmp(argv[1], "-h")==0 || strcmp(argv[1], "--help")==0) {
-        fprintf(stderr, usage_str, argv[0]);
+        printf(usage_str, argv[0]);
         exit(1);
     }
 
@@ -348,7 +348,7 @@ void parse_cli(int argc, char** argv, struct cli_params *params)
         parse_infocert_cli(argc, argv, params);
     } else
     {
-        printf("'%s' is not an option for the XTT tool.\n", argv[1]);
+        fprintf(stderr, "'%s' is not an option for the XTT tool.\n", argv[1]);
         fprintf(stderr, usage_str, argv[0]);
         exit(1);
     }

--- a/tool/xtt.c
+++ b/tool/xtt.c
@@ -71,28 +71,28 @@ int main(int argc, char **argv)
 
     switch(out){
         case SAVE_TO_FILE_ERROR:
-            printf("Error writing to a file\n");
+            fprintf(stderr, "Error writing to a file\n");
             break;
         case READ_FROM_FILE_ERROR:
-            printf("Error reading from a file\n");
+            fprintf(stderr, "Error reading from a file\n");
             break;
         case KEY_CREATION_ERROR:
-            printf("Error creating ecdsap256 keypair\n");
+            fprintf(stderr, "Error creating ecdsap256 keypair\n");
             break;
         case CERT_CREATION_ERROR:
-            printf("Error creating certificate\n");
+            fprintf(stderr, "Error creating certificate\n");
             break;
         case ASN1_CREATION_ERROR:
-            printf("Error creating ASN.1 wrapped keys\n");
+            fprintf(stderr, "Error creating ASN.1 wrapped keys\n");
             break;
         case EXPIRY_PASSED:
-            printf("Expiry has already passed\n");
+            fprintf(stderr, "Expiry has already passed\n");
             break;
         case PARSE_CERT_ERROR:
-            printf("Error parsing certificate: must pass in a certificate\n");
+            fprintf(stderr, "Error parsing certificate: must pass in a certificate\n");
             break;
         case SUCCESS:
-            printf("ok\n");
+            fprintf(stderr, "ok\n");
             break;
         case VOID_SUCCESS:
             break;


### PR DESCRIPTION
Fixes #66 Instead of printing out error messages to the screen or file, print error messages as stderror's.