### PR TITLE
Add Standardized TPM handles

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,7 @@ set(XTT_SRCS
         src/internal/message_utils.c
         src/internal/server_cookie.c
         src/internal/signatures.c
+        src/tpm/handles.c
         )
 
 ################################################################################

--- a/examples/xtt_client.c
+++ b/examples/xtt_client.c
@@ -43,14 +43,6 @@
 typedef int TSS2_TCTI_CONTEXT;
 #endif
 
-uint32_t key_handle_g = 0x81800000;
-uint32_t gpk_handle_g = 0x1410000;
-uint32_t cred_handle_g = 0x1410001;
-uint32_t root_id_handle_g = 0x1410003;
-uint32_t root_pubkey_handle_g = 0x1410004;
-uint32_t basename_size_handle_g = 0x1410006;
-uint32_t basename_handle_g = 0x1410007;
-uint32_t server_id_handle_g = 0x1410008;
 const char *tpm_hostname_g = "localhost";
 const char *tpm_port_g = "2321";
 const size_t tpm_devfile_length_g = 9;
@@ -410,7 +402,7 @@ int initialize_server_id(xtt_identity_type *intended_server_id,
         int nvram_ret;
         nvram_ret = read_nvram(intended_server_id->data,
                                sizeof(xtt_identity_type),
-                               server_id_handle_g,
+                               XTT_SERVER_ID_HANDLE,
                                tcti_context);
         if (0 != nvram_ret) {
             fprintf(stderr, "Error reading server id from TPM NVRAM");
@@ -449,7 +441,7 @@ int initialize_daa(struct xtt_client_group_context *group_ctx, int use_tpm, TSS2
         uint8_t basename_len_from_tpm = 0;
         nvram_ret = read_nvram((unsigned char*)&basename_len_from_tpm,
                                1,
-                               basename_size_handle_g,
+                               XTT_BASENAME_SIZE_HANDLE,
                                tcti_context);
         if (0 != nvram_ret) {
             fprintf(stderr, "Error reading basename size from TPM NVRAM\n");
@@ -458,7 +450,7 @@ int initialize_daa(struct xtt_client_group_context *group_ctx, int use_tpm, TSS2
         basename_len = basename_len_from_tpm;
         nvram_ret = read_nvram(basename,
                                basename_len,
-                               basename_handle_g,
+                               XTT_BASENAME_HANDLE,
                                tcti_context);
         if (0 != nvram_ret) {
             fprintf(stderr, "Error reading basename from TPM NVRAM\n");
@@ -467,7 +459,7 @@ int initialize_daa(struct xtt_client_group_context *group_ctx, int use_tpm, TSS2
 
         nvram_ret = read_nvram(gpk.data,
                                sizeof(xtt_daa_group_pub_key_lrsw),
-                               gpk_handle_g,
+                               XTT_GPK_HANDLE,
                                tcti_context);
         if (0 != nvram_ret) {
             fprintf(stderr, "Error reading GPK from TPM NVRAM");
@@ -476,7 +468,7 @@ int initialize_daa(struct xtt_client_group_context *group_ctx, int use_tpm, TSS2
 
         nvram_ret = read_nvram(cred.data,
                                sizeof(xtt_daa_credential_lrsw),
-                               cred_handle_g,
+                               XTT_CRED_HANDLE,
                                tcti_context);
         if (0 != nvram_ret) {
             fprintf(stderr, "Error reading credential from TPM NVRAM");
@@ -536,7 +528,7 @@ int initialize_daa(struct xtt_client_group_context *group_ctx, int use_tpm, TSS2
                                                          &cred,
                                                          (unsigned char*)basename,
                                                          basename_len,
-                                                         key_handle_g,
+                                                         XTT_KEY_HANDLE,
                                                          tpm_password,
                                                          tpm_password_len,
                                                          tcti_context);
@@ -574,7 +566,7 @@ int initialize_certs(int use_tpm,
         int nvram_ret;
         nvram_ret = read_nvram(root_id.data,
                                sizeof(xtt_certificate_root_id),
-                               root_id_handle_g,
+                               XTT_ROOT_ID_HANDLE,
                                tcti_context);
         if (0 != nvram_ret) {
             fprintf(stderr, "Error reading root ID from TPM NVRAM");
@@ -583,7 +575,7 @@ int initialize_certs(int use_tpm,
 
         nvram_ret = read_nvram(root_public_key.data,
                                sizeof(xtt_ecdsap256_pub_key),
-                               root_pubkey_handle_g,
+                               XTT_ROOT_PUBKEY_HANDLE,
                                tcti_context);
         if (0 != nvram_ret) {
             fprintf(stderr, "Error reading root's public key from TPM NVRAM");

--- a/include/xtt/tpm/handles.h
+++ b/include/xtt/tpm/handles.h
@@ -16,25 +16,34 @@
  *
  *****************************************************************************/
 
-#ifndef XTT_H
-#define XTT_H
+#ifndef XTT_TPM_HANDLES_H
+#define XTT_TPM_HANDLES_H
 #pragma once
 
-#include <xtt/certificates.h>
-#include <xtt/context.h>
-#include <xtt/crypto_wrapper.h>
-#include <xtt/crypto_types.h>
-#include <xtt/daa_wrapper.h>
-#include <xtt/return_codes.h>
-#include <xtt/messages.h>
-#include <xtt/util/asn1.h>
-#include <xtt/util/generate_ecdsap256_keys.h>
-#include <xtt/util/generate_x509_certificate.h>
-#include <xtt/util/wrap_keys_asn1.h>
-#include <xtt/util/root.h>
-#include <xtt/util/generate_server_certificate.h>
-#include <xtt/util/file_io.h>
-#include <xtt/util/util_errors.h>
-#include <xtt/tpm/handles.h>
+#include <stdint.h>
+
+#define XTT_KEY_HANDLE 0x81800000
+uint32_t xtt_key_handle(void);
+
+#define XTT_GPK_HANDLE 0x1410000
+uint32_t xtt_gpk_handle(void);
+
+#define XTT_CRED_HANDLE 0x1410001
+uint32_t xtt_cred_handle(void);
+
+#define XTT_ROOT_ID_HANDLE 0x1410003
+uint32_t xtt_root_id_handle(void);
+
+#define XTT_ROOT_PUBKEY_HANDLE 0x1410004
+uint32_t xtt_root_pubkey_handle(void);
+
+#define XTT_BASENAME_SIZE_HANDLE 0x1410006
+uint32_t xtt_basename_size_handle(void);
+
+#define XTT_BASENAME_HANDLE 0x1410007
+uint32_t xtt_basename_handle(void);
+
+#define XTT_SERVER_ID_HANDLE 0x1410008
+uint32_t xtt_server_id_handle(void);
 
 #endif

--- a/src/tpm/handles.c
+++ b/src/tpm/handles.c
@@ -16,25 +16,44 @@
  *
  *****************************************************************************/
 
-#ifndef XTT_H
-#define XTT_H
-#pragma once
-
-#include <xtt/certificates.h>
-#include <xtt/context.h>
-#include <xtt/crypto_wrapper.h>
-#include <xtt/crypto_types.h>
-#include <xtt/daa_wrapper.h>
-#include <xtt/return_codes.h>
-#include <xtt/messages.h>
-#include <xtt/util/asn1.h>
-#include <xtt/util/generate_ecdsap256_keys.h>
-#include <xtt/util/generate_x509_certificate.h>
-#include <xtt/util/wrap_keys_asn1.h>
-#include <xtt/util/root.h>
-#include <xtt/util/generate_server_certificate.h>
-#include <xtt/util/file_io.h>
-#include <xtt/util/util_errors.h>
 #include <xtt/tpm/handles.h>
 
-#endif
+uint32_t xtt_key_handle(void)
+{
+    return XTT_KEY_HANDLE;
+}
+
+uint32_t xtt_gpk_handle(void)
+{
+    return XTT_GPK_HANDLE;
+}
+
+uint32_t xtt_cred_handle(void)
+{
+    return XTT_CRED_HANDLE;
+}
+
+uint32_t xtt_root_id_handle(void)
+{
+    return XTT_ROOT_ID_HANDLE;
+}
+
+uint32_t xtt_root_pubkey_handle(void)
+{
+    return XTT_ROOT_PUBKEY_HANDLE;
+}
+
+uint32_t xtt_basename_size_handle(void)
+{
+    return XTT_BASENAME_SIZE_HANDLE;
+}
+
+uint32_t xtt_basename_handle(void)
+{
+    return XTT_BASENAME_HANDLE;
+}
+
+uint32_t xtt_server_id_handle(void)
+{
+    return XTT_SERVER_ID_HANDLE;
+}

--- a/tool/client.c
+++ b/tool/client.c
@@ -37,6 +37,7 @@
 #include <xtt/util/file_io.h>
 #include <xtt/util/asn1.h>
 #include <xtt/util/root.h>
+#include <xtt/tpm/handles.h>
 
 #ifdef USE_TPM
 #include <tss2/tss2_sys.h>
@@ -46,15 +47,6 @@
 typedef int TSS2_TCTI_CONTEXT;
 #endif
 
-
-uint32_t key_handle_g = 0x81800000;
-uint32_t gpk_handle_g = 0x1410000;
-uint32_t cred_handle_g = 0x1410001;
-uint32_t root_id_handle_g = 0x1410003;
-uint32_t root_pubkey_handle_g = 0x1410004;
-uint32_t basename_size_handle_g = 0x1410006;
-uint32_t basename_handle_g = 0x1410007;
-uint32_t server_id_handle_g = 0x1410008;
 const char *tpm_hostname_g = "localhost";
 const char *tpm_port_g = "2321";
 const size_t tpm_devfile_length_g = 9;
@@ -360,7 +352,7 @@ int initialize_server_id(xtt_identity_type *intended_server_id,
         int nvram_ret = 0;
         nvram_ret = read_nvram(intended_server_id->data,
                                sizeof(xtt_identity_type),
-                               server_id_handle_g,
+                               XTT_SERVER_ID_HANDLE,
                                tcti_context);
         if (0 != nvram_ret) {
             fprintf(stderr, "Error reading server id from TPM NVRAM");
@@ -397,7 +389,7 @@ int initialize_daa(struct xtt_client_group_context *group_ctx, int use_tpm, TSS2
         uint8_t basename_len_from_tpm = 0;
         nvram_ret = read_nvram((unsigned char*)&basename_len_from_tpm,
                                1,
-                               basename_size_handle_g,
+                               XTT_BASENAME_SIZE_HANDLE,
                                tcti_context);
         if (0 != nvram_ret) {
             fprintf(stderr, "Error reading basename size from TPM NVRAM\n");
@@ -406,7 +398,7 @@ int initialize_daa(struct xtt_client_group_context *group_ctx, int use_tpm, TSS2
         basename_len = basename_len_from_tpm;
         nvram_ret = read_nvram(basename,
                                basename_len,
-                               basename_handle_g,
+                               XTT_BASENAME_HANDLE,
                                tcti_context);
         if (0 != nvram_ret) {
             fprintf(stderr, "Error reading basename from TPM NVRAM\n");
@@ -415,7 +407,7 @@ int initialize_daa(struct xtt_client_group_context *group_ctx, int use_tpm, TSS2
 
         nvram_ret = read_nvram(gpk.data,
                                sizeof(xtt_daa_group_pub_key_lrsw),
-                               gpk_handle_g,
+                               XTT_GPK_HANDLE,
                                tcti_context);
         if (0 != nvram_ret) {
             fprintf(stderr, "Error reading GPK from TPM NVRAM");
@@ -424,7 +416,7 @@ int initialize_daa(struct xtt_client_group_context *group_ctx, int use_tpm, TSS2
 
         nvram_ret = read_nvram(cred.data,
                                sizeof(xtt_daa_credential_lrsw),
-                               cred_handle_g,
+                               XTT_CRED_HANDLE,
                                tcti_context);
         if (0 != nvram_ret) {
             fprintf(stderr, "Error reading credential from TPM NVRAM");
@@ -482,7 +474,7 @@ int initialize_daa(struct xtt_client_group_context *group_ctx, int use_tpm, TSS2
                                                          &cred,
                                                          (unsigned char*)basename,
                                                          basename_len,
-                                                         key_handle_g,
+                                                         XTT_KEY_HANDLE,
                                                          tpm_password,
                                                          tpm_password_len,
                                                          tcti_context);
@@ -521,7 +513,7 @@ int initialize_certs(int use_tpm,
         int nvram_ret;
         nvram_ret = read_nvram(root_id.data,
                                sizeof(xtt_certificate_root_id),
-                               root_id_handle_g,
+                               XTT_ROOT_ID_HANDLE,
                                tcti_context);
         if (0 != nvram_ret) {
             fprintf(stderr, "Error reading root ID from TPM NVRAM");
@@ -530,7 +522,7 @@ int initialize_certs(int use_tpm,
 
         nvram_ret = read_nvram(root_public_key.data,
                                sizeof(xtt_ecdsap256_pub_key),
-                               root_pubkey_handle_g,
+                               XTT_ROOT_PUBKEY_HANDLE,
                                tcti_context);
         if (0 != nvram_ret) {
             fprintf(stderr, "Error reading root's public key from TPM NVRAM");


### PR DESCRIPTION
Instead of having to set the handles' values with each handshake, we have put them in a header file that sets a `#define` for each of the handles that we use.

Fixes #73.