### PR TITLE
tool: Don't hardcode basename length in client.c

### DIFF
--- a/tool/client.c
+++ b/tool/client.c
@@ -435,7 +435,7 @@ int initialize_daa(struct xtt_client_group_context *group_ctx, int use_tpm, TSS2
         return TPM_ERROR;
 #endif
     } else {
-        int read_ret = xtt_read_from_file(basename_file, basename, 8);
+        int read_ret = xtt_read_from_file(basename_file, basename, sizeof(basename));
         if (read_ret < 0) {
             return READ_FROM_FILE_ERROR;
         }


### PR DESCRIPTION
The client code in the tool was using a hardcoded length for the basename of 8 bytes (which is the length of the example basename). The `xtt_read_from_file` function allows unknown-length file reads, so we need to use that (just as is done in the server code).