### PR TITLE
travis: pin ecdaa to a specific version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ env:
   global:
     - INSTALL_PREFIX=${TRAVIS_BUILD_DIR}/usr
     - CMAKE_PREFIX_PATH=${INSTALL_PREFIX}
+    - LIBSODIUM_TAG=1.0.11
     - LIBSODIUM_DIR=${TRAVIS_BUILD_DIR}/libsodium
     - AMCL_TAG=4.7.0
     - AMCL_DIR=${TRAVIS_BUILD_DIR}/milagro-crypto-c/install
@@ -35,7 +36,7 @@ jobs:
   # Release build, gcc
   - env: TYPE=RELEASE
     before_script:
-      - .travis/install-libsodium.sh ${LIBSODIUM_DIR}
+      - .travis/install-libsodium.sh ${LIBSODIUM_TAG} ${LIBSODIUM_DIR}
       - .travis/install-xaptum-tpm.sh ${XAPTUM_TPM_TAG} ${XAPTUM_TPM_DIR}
       - .travis/install-amcl.sh ${AMCL_TAG} ${AMCL_DIR} ${AMCL_CURVES}
       - .travis/install-ecdaa.sh ${ECDAA_TAG} ${ECDAA_DIR}

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,56 +30,35 @@ env:
     - ECDAA_TAG=v0.9.1
     - ECDAA_DIR=${TRAVIS_BUILD_DIR}/ecdaa
 
-jobs:
+before_script:
+  - .travis/install-libsodium.sh ${LIBSODIUM_TAG} ${LIBSODIUM_DIR}
+  - .travis/install-xaptum-tpm.sh ${XAPTUM_TPM_TAG} ${XAPTUM_TPM_DIR}
+  - .travis/install-amcl.sh ${AMCL_TAG} ${AMCL_DIR} ${AMCL_CURVES}
+  - .travis/install-ecdaa.sh ${ECDAA_TAG} ${ECDAA_DIR}
+  - cmake . -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DBUILD_EXAMPLES=ON
+
+script:
+  - cmake --build . -- -j2
+  - ctest -E tpm -VV
+
+matrix:
   include:
-
-  # Release build, gcc
-  - env: TYPE=RELEASE
-    before_script:
-      - .travis/install-libsodium.sh ${LIBSODIUM_TAG} ${LIBSODIUM_DIR}
-      - .travis/install-xaptum-tpm.sh ${XAPTUM_TPM_TAG} ${XAPTUM_TPM_DIR}
-      - .travis/install-amcl.sh ${AMCL_TAG} ${AMCL_DIR} ${AMCL_CURVES}
-      - .travis/install-ecdaa.sh ${ECDAA_TAG} ${ECDAA_DIR}
-      - cmake . -DCMAKE_BUILD_TYPE=Release -DBUILD_EXAMPLES=ON
-    script:
-      - cmake --build . -- -j2
-      - ctest -E tpm -VV
-
-  # Debug build
-  - env: TYPE=DEBUG
-    before_script:
-      - .travis/install-libsodium.sh ${LIBSODIUM_DIR}
-      - .travis/install-xaptum-tpm.sh ${XAPTUM_TPM_DIR}
-      - .travis/install-amcl.sh ${AMCL_DIR} ${AMCL_CURVES}
-      - .travis/install-ecdaa.sh ${ECDAA_DIR}
-      - cmake . -DCMAKE_BUILD_TYPE=Debug -DBUILD_EXAMPLES=ON
-    script:
-      - cmake --build . -- -j2
-      - ctest -E tpm -VV
-
-  # Release build, clang
-  - env: TYPE=RELEASE-WITH-CLANG
-    compiler: clang
-    before_script:
-      - .travis/install-libsodium.sh ${LIBSODIUM_DIR}
-      - .travis/install-xaptum-tpm.sh ${XAPTUM_TPM_DIR}
-      - .travis/install-amcl.sh ${AMCL_DIR} ${AMCL_CURVES}
-      - .travis/install-ecdaa.sh ${ECDAA_DIR}
-      - cmake . -DCMAKE_BUILD_TYPE=Release -DBUILD_EXAMPLES=ON
-    script:
-      - cmake --build . -- -j2
-      - ctest -E tpm -VV
-
-  # Sanitizers
-  - env: TYPE=SANITIZE
-    sudo: true
-    compiler: clang
-    before_script:
-      - .travis/install-libsodium.sh ${LIBSODIUM_DIR}
-      - .travis/install-xaptum-tpm.sh ${XAPTUM_TPM_DIR}
-      - .travis/install-amcl.sh ${AMCL_DIR} ${AMCL_CURVES}
-      - .travis/install-ecdaa.sh ${ECDAA_DIR}
-      - cmake . -DCMAKE_BUILD_TYPE=RelWithSanitize -DBUILD_EXAMPLES=ON
-    script:
-      - cmake --build . -- -j2
-      - ctest -E tpm -VV
+    - name: "Release build, gcc"
+      env:
+        - TYPE=RELEASE
+        - BUILD_TYPE=Release
+    - name: "Debug build, gcc"
+      env:
+        - TYPE=DEBUG
+        - BUILD_TYPE=Debug
+    - name: "Release build, clang"
+      compiler: clang
+      env:
+        - TYPE=RELEASE-WITH-CLANG
+        - BUILD_TYPE=Release
+    - name: "Sanitize build, clang"
+      sudo: true
+      compiler: clang
+      env:
+        - TYPE=SANITIZE
+        - BUILD_TYPE=RelWithSanitize

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ env:
     - LIBSODIUM_DIR=${TRAVIS_BUILD_DIR}/libsodium
     - AMCL_TAG=4.7.0
     - AMCL_DIR=${TRAVIS_BUILD_DIR}/milagro-crypto-c/install
+    - XAPTUM_TPM_TAG=v0.5.6
     - XAPTUM_TPM_DIR=${TRAVIS_BUILD_DIR}/xaptum-tpm/
     - AMCL_CURVES=FP256BN,NIST256
     - ECDAA_TAG=v0.9.1
@@ -35,7 +36,7 @@ jobs:
   - env: TYPE=RELEASE
     before_script:
       - .travis/install-libsodium.sh ${LIBSODIUM_DIR}
-      - .travis/install-xaptum-tpm.sh ${XAPTUM_TPM_DIR}
+      - .travis/install-xaptum-tpm.sh ${XAPTUM_TPM_TAG} ${XAPTUM_TPM_DIR}
       - .travis/install-amcl.sh ${AMCL_TAG} ${AMCL_DIR} ${AMCL_CURVES}
       - .travis/install-ecdaa.sh ${ECDAA_TAG} ${ECDAA_DIR}
       - cmake . -DCMAKE_BUILD_TYPE=Release -DBUILD_EXAMPLES=ON

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ env:
     - AMCL_DIR=${TRAVIS_BUILD_DIR}/milagro-crypto-c/install
     - XAPTUM_TPM_DIR=${TRAVIS_BUILD_DIR}/xaptum-tpm/
     - AMCL_CURVES=FP256BN,NIST256
+    - ECDAA_TAG=v0.9.1
     - ECDAA_DIR=${TRAVIS_BUILD_DIR}/ecdaa
 
 jobs:
@@ -35,7 +36,7 @@ jobs:
       - .travis/install-libsodium.sh ${LIBSODIUM_DIR}
       - .travis/install-xaptum-tpm.sh ${XAPTUM_TPM_DIR}
       - .travis/install-amcl.sh ${AMCL_DIR} ${AMCL_CURVES}
-      - .travis/install-ecdaa.sh ${ECDAA_DIR}
+      - .travis/install-ecdaa.sh ${ECDAA_TAG} ${ECDAA_DIR}
       - cmake . -DCMAKE_BUILD_TYPE=Release -DBUILD_EXAMPLES=ON
     script:
       - cmake --build . -- -j2

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ env:
     - INSTALL_PREFIX=${TRAVIS_BUILD_DIR}/usr
     - CMAKE_PREFIX_PATH=${INSTALL_PREFIX}
     - LIBSODIUM_DIR=${TRAVIS_BUILD_DIR}/libsodium
+    - AMCL_TAG=4.7.0
     - AMCL_DIR=${TRAVIS_BUILD_DIR}/milagro-crypto-c/install
     - XAPTUM_TPM_DIR=${TRAVIS_BUILD_DIR}/xaptum-tpm/
     - AMCL_CURVES=FP256BN,NIST256
@@ -35,7 +36,7 @@ jobs:
     before_script:
       - .travis/install-libsodium.sh ${LIBSODIUM_DIR}
       - .travis/install-xaptum-tpm.sh ${XAPTUM_TPM_DIR}
-      - .travis/install-amcl.sh ${AMCL_DIR} ${AMCL_CURVES}
+      - .travis/install-amcl.sh ${AMCL_TAG} ${AMCL_DIR} ${AMCL_CURVES}
       - .travis/install-ecdaa.sh ${ECDAA_TAG} ${ECDAA_DIR}
       - cmake . -DCMAKE_BUILD_TYPE=Release -DBUILD_EXAMPLES=ON
     script:

--- a/.travis/install-amcl.sh
+++ b/.travis/install-amcl.sh
@@ -15,16 +15,16 @@
 
 set -e
 
-if [[ $# -ne 2 ]]; then
-        echo "usage: $0 <absolute-path-to-amcl-source-directory> <comma-separated-curve-list>"
+if [[ $# -ne 3 ]]; then
+        echo "usage: $0 <git-tag> <absolute-path-to-amcl-source-directory> <comma-separated-curve-list>"
         exit 1
 fi
 
 repo_url=https://github.com/milagro-crypto/milagro-crypto-c
-tag=4.7.0
-source_dir="$1"
-curves="$2"
-git clone -b $tag "${repo_url}" "${source_dir}"
+source_tag="$1"
+source_dir="$2"
+curves="$3"
+git clone --branch "${source_tag}" --depth 1 "${repo_url}" "${source_dir}"
 pushd "${source_dir}"
 mkdir -p build
 pushd build

--- a/.travis/install-ecdaa.sh
+++ b/.travis/install-ecdaa.sh
@@ -15,14 +15,15 @@
 
 set -e
 
-if [[ $# -ne 1 ]]; then
-        echo "usage: $0 <absolute-path-to-ecdaa-source-directory>"
+if [[ $# -ne 2 ]]; then
+        echo "usage: $0 <git-tag> <absolute-path-to-ecdaa-source-directory>"
         exit 1
 fi
 
-source_dir="$1"
-git clone https://github.com/xaptum/ecdaa "${source_dir}" 
-pushd "${source_dir}" 
+source_tag="$1"
+source_dir="$2"
+git clone --branch "${source_tag}" --depth 1 https://github.com/xaptum/ecdaa "${source_dir}"
+pushd "${source_dir}"
 mkdir -p build
 pushd build
 cmake .. -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} -DCMAKE_PREFIX_PATH=${local_install_dir}

--- a/.travis/install-libsodium.sh
+++ b/.travis/install-libsodium.sh
@@ -15,18 +15,18 @@
 
 set -e
 
-if [[ $# -ne 1 ]]; then
-        echo "usage: $0 <absolute-path-to-libsodium-source-directory>"
+if [[ $# -ne 2 ]]; then
+        echo "usage: $0 <version> <absolute-path-to-libsodium-source-directory>"
         exit 1
 fi
 
-version=1.0.11
-source_dir="$1"
+source_tag="$1"
+source_dir="$2"
 mkdir -p ${source_dir}
 pushd ${source_dir}
-wget https://download.libsodium.org/libsodium/releases/old/unsupported/libsodium-${version}.tar.gz
-tar xvfz libsodium-${version}.tar.gz
-pushd libsodium-${version}
+wget https://download.libsodium.org/libsodium/releases/old/unsupported/libsodium-${source_tag}.tar.gz
+tar xvfz libsodium-${source_tag}.tar.gz
+pushd libsodium-${source_tag}
 ./configure --prefix=${INSTALL_PREFIX}
 make
 make install

--- a/.travis/install-xaptum-tpm.sh
+++ b/.travis/install-xaptum-tpm.sh
@@ -15,13 +15,14 @@
 
 set -e
 
-if [[ $# -ne 1 ]]; then
-        echo "usage: $0 <absolute-path-to-xaptum-tpm-source-directory>"
+if [[ $# -ne 2 ]]; then
+        echo "usage: $0 <git-tag> <absolute-path-to-xaptum-tpm-source-directory>"
         exit 1
 fi
 
-source_dir="$1"
-git clone https://github.com/xaptum/xaptum-tpm "${source_dir}"
+source_tag="$1"
+source_dir="$2"
+git clone --branch "${source_tag}" --depth 1 https://github.com/xaptum/xaptum-tpm "${source_dir}"
 pushd "${source_dir}"
 mkdir -p build
 pushd build


### PR DESCRIPTION
- pin the dependency version to fix the travis build
- DRY up travis.yml by specifying a build matrix