### PR TITLE
tool: read root cert fix

### DIFF
--- a/include/xtt/tpm/handles.h
+++ b/include/xtt/tpm/handles.h
@@ -31,12 +31,6 @@ uint32_t xtt_gpk_handle(void);
 #define XTT_CRED_HANDLE 0x1410001
 uint32_t xtt_cred_handle(void);
 
-#define XTT_ROOT_ID_HANDLE 0x1410003
-uint32_t xtt_root_id_handle(void);
-
-#define XTT_ROOT_PUBKEY_HANDLE 0x1410004
-uint32_t xtt_root_pubkey_handle(void);
-
 #define XTT_BASENAME_SIZE_HANDLE 0x1410006
 uint32_t xtt_basename_size_handle(void);
 
@@ -45,5 +39,9 @@ uint32_t xtt_basename_handle(void);
 
 #define XTT_SERVER_ID_HANDLE 0x1410008
 uint32_t xtt_server_id_handle(void);
+
+#define XTT_ROOT_CERT_HANDLE 0x1410009
+uint32_t xtt_root_cert_handle(void);
+
 
 #endif

--- a/src/tpm/handles.c
+++ b/src/tpm/handles.c
@@ -33,16 +33,6 @@ uint32_t xtt_cred_handle(void)
     return XTT_CRED_HANDLE;
 }
 
-uint32_t xtt_root_id_handle(void)
-{
-    return XTT_ROOT_ID_HANDLE;
-}
-
-uint32_t xtt_root_pubkey_handle(void)
-{
-    return XTT_ROOT_PUBKEY_HANDLE;
-}
-
 uint32_t xtt_basename_size_handle(void)
 {
     return XTT_BASENAME_SIZE_HANDLE;
@@ -56,4 +46,9 @@ uint32_t xtt_basename_handle(void)
 uint32_t xtt_server_id_handle(void)
 {
     return XTT_SERVER_ID_HANDLE;
+}
+
+uint32_t xtt_root_cert_handle(void)
+{
+    return XTT_ROOT_CERT_HANDLE;
 }


### PR DESCRIPTION
Changes the client code to only read in a root cert file while using software DAA. If using the TPM, this will read in an `xtt_root_certificate` from the TPM itself. Adds a TPM handle for the root certificate.

Fixes #95 

