### PR TITLE
tool: remove priv key from genrootcert

### DIFF
--- a/include/xtt/util/root.h
+++ b/include/xtt/util/root.h
@@ -47,7 +47,7 @@ void xtt_deserialize_root_certificate(xtt_ecdsap256_pub_key *pub_key, xtt_certif
  *      READ_FROM_FILE_ERROR    an error occurred reading from a file
  *      KEY_CREATION_ERROR      an error occurred creating a keypair
 */
-int xtt_generate_root(const char *privkey_filename, const char *pubkey_filename, const char *id_filename, const char *cert_filename);
+int xtt_generate_root(const char *pubkey_filename, const char *id_filename, const char *cert_filename);
 
 #ifdef __cplusplus
 }

--- a/src/util/root.c
+++ b/src/util/root.c
@@ -32,7 +32,7 @@ void xtt_deserialize_root_certificate(xtt_ecdsap256_pub_key *pub_key, xtt_certif
     memcpy(pub_key->data, &root_cert_in->data[sizeof(xtt_certificate_root_id)], sizeof(xtt_ecdsap256_pub_key));
 }
 
-int xtt_generate_root(const char *privkey_filename, const char *pubkey_filename, const char *id_filename, const char *cert_filename)
+int xtt_generate_root(const char *pubkey_filename, const char *id_filename, const char *cert_filename)
 {
     int read_ret = 0;
     // 1) Read root id from file, assigning root_id a random number if there is no file given
@@ -49,15 +49,9 @@ int xtt_generate_root(const char *privkey_filename, const char *pubkey_filename,
 
     // 2) Generate root's keypair
     xtt_ecdsap256_pub_key pub = {.data = {0}};
-    xtt_ecdsap256_priv_key priv = {.data = {0}};
 
     read_ret = xtt_read_from_file(pubkey_filename, pub.data, sizeof(xtt_ecdsap256_pub_key));
     if(read_ret < 0){
-        return READ_FROM_FILE_ERROR;
-    }
-
-    read_ret = xtt_read_from_file(privkey_filename, priv.data, sizeof(xtt_ecdsap256_priv_key));
-    if (read_ret < 0){
         return READ_FROM_FILE_ERROR;
     }
 
@@ -67,11 +61,6 @@ int xtt_generate_root(const char *privkey_filename, const char *pubkey_filename,
 
     // 4) Save info to files
     int write_ret = xtt_save_to_file(pub.data, sizeof(xtt_ecdsap256_pub_key), pubkey_filename);
-    if(write_ret < 0){
-        return SAVE_TO_FILE_ERROR;
-    }
-
-    write_ret = xtt_save_to_file(priv.data, sizeof(xtt_ecdsap256_priv_key), privkey_filename);
     if(write_ret < 0){
         return SAVE_TO_FILE_ERROR;
     }

--- a/tool/parse_cli.c
+++ b/tool/parse_cli.c
@@ -156,15 +156,13 @@ void parse_wrapkeys_cli(int argc, char **argv, struct cli_params *params)
 static
 void parse_genroot_cli(int argc, char **argv, struct cli_params *params)
 {
-    params->privkey = "root_priv.bin";
     params->pubkey = "root_pub.bin";
     params->id = NULL;
     params->rootcert = "root_cert.bin";
     const char *usage_str = "Generate a root certificate.\n\n"
-        "Usage: %s %s [-h] [-v <file>] [-b <file>] [-d <file>] [-c <file>]\n"
+        "Usage: %s %s [-h] [-b <file>] [-d <file>] [-c <file>]\n"
         "\tOptions:\n"
         "\t\t-h --help                      Display this message.\n"
-        "\t\t-v --rpriv                     Root's private key input location [default = root_priv.bin]\n"
         "\t\t-b --rpub                      Root's public key input location [default = root_pub.bin]\n"
         "\t\t-d --rid                       Root's ID input location [default generates a random ID]\n"
         "\t\t-c --rcert                     Root's certificate key output location [default = root_cert.bin]\n"
@@ -172,7 +170,6 @@ void parse_genroot_cli(int argc, char **argv, struct cli_params *params)
 
     static struct option cli_options[] =
     {
-        {"rpriv", required_argument, NULL, 'v'},
         {"rpub", required_argument, NULL, 'b'},
         {"rid", required_argument, NULL, 'd'},
         {"rcert", required_argument, NULL, 'c'},
@@ -181,11 +178,8 @@ void parse_genroot_cli(int argc, char **argv, struct cli_params *params)
     };
 
     int c;
-    while ((c = getopt_long(argc, argv, "v:b:d:c:h", cli_options, NULL)) != -1) {
+    while ((c = getopt_long(argc, argv, "b:d:c:h", cli_options, NULL)) != -1) {
         switch (c) {
-            case 'v':
-                params->privkey = optarg;
-                break;
             case 'b':
                 params->pubkey = optarg;
                 break;

--- a/tool/xtt.c
+++ b/tool/xtt.c
@@ -51,7 +51,7 @@ int main(int argc, char **argv)
             out = xtt_wrap_keys_asn1(params.privkey, params.pubkey, params.asn1);
             break;
         case action_genrootcert:
-            out = xtt_generate_root(params.privkey, params.pubkey, params.id, params.rootcert);
+            out = xtt_generate_root(params.pubkey, params.id, params.rootcert);
             break;
         case action_genservercert:
             out = xtt_generate_server_certificate(params.rootcert, params.rootpriv, params.serverpriv, params.serverpub, params.server_id, params.time, params.servercert);


### PR DESCRIPTION
Generating a root certificate used to require a private key, which is unnecessary. Each part of the tool is not independent, so there is no need to create a key pair within genrootcert.