### PR TITLE
Travis add builds for static libs and install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,13 +29,14 @@ env:
     - AMCL_CURVES=FP256BN,NIST256
     - ECDAA_TAG=v0.10.0
     - ECDAA_DIR=${TRAVIS_BUILD_DIR}/ecdaa
+    - SHARED_LIBS=ON
 
 before_script:
   - .travis/install-libsodium.sh ${LIBSODIUM_TAG} ${LIBSODIUM_DIR}
   - .travis/install-xaptum-tpm.sh ${XAPTUM_TPM_TAG} ${XAPTUM_TPM_DIR}
   - .travis/install-amcl.sh ${AMCL_TAG} ${AMCL_DIR} ${AMCL_CURVES}
   - .travis/install-ecdaa.sh ${ECDAA_TAG} ${ECDAA_DIR}
-  - cmake . -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DBUILD_EXAMPLES=ON
+  - cmake . -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DBUILD_EXAMPLES=ON -DBUILD_SHARED_LIBS=${SHARED_LIBS}
 
 script:
   - cmake --build . -- -j2
@@ -47,6 +48,11 @@ matrix:
       env:
         - TYPE=RELEASE
         - BUILD_TYPE=Release
+    - name: "Dev build, gcc, static library"
+      env:
+        - TYPE=DEV
+        - BUILD_TYPE=Dev
+        - SHARED_LIBS=OFF
     - name: "Debug build, gcc"
       env:
         - TYPE=DEBUG

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,16 +30,18 @@ env:
     - ECDAA_TAG=v0.10.0
     - ECDAA_DIR=${TRAVIS_BUILD_DIR}/ecdaa
     - SHARED_LIBS=ON
+    - XTT_INSTALL_DIR=${TRAVIS_BUILD_DIR}/install
 
 before_script:
   - .travis/install-libsodium.sh ${LIBSODIUM_TAG} ${LIBSODIUM_DIR}
   - .travis/install-xaptum-tpm.sh ${XAPTUM_TPM_TAG} ${XAPTUM_TPM_DIR}
   - .travis/install-amcl.sh ${AMCL_TAG} ${AMCL_DIR} ${AMCL_CURVES}
   - .travis/install-ecdaa.sh ${ECDAA_TAG} ${ECDAA_DIR}
-  - cmake . -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DBUILD_EXAMPLES=ON -DBUILD_SHARED_LIBS=${SHARED_LIBS}
+  - mkdir -p ${XTT_INSTALL_DIR}
+  - cmake . -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DCMAKE_INSTALL_PREFIX=${XTT_INSTALL_DIR} -DBUILD_SHARED_LIBS=${SHARED_LIBS}
 
 script:
-  - cmake --build . -- -j2
+  - cmake --build . --target install -- -j2
   - ctest -E tpm -VV
 
 matrix:
@@ -48,10 +50,8 @@ matrix:
       env:
         - TYPE=RELEASE
         - BUILD_TYPE=Release
-    - name: "Dev build, gcc, static library"
+    - name: "Build with static library, gcc"
       env:
-        - TYPE=DEV
-        - BUILD_TYPE=Dev
         - SHARED_LIBS=OFF
     - name: "Debug build, gcc"
       env:


### PR DESCRIPTION
Fixes #102 and removes `-DBUILD_EXAMPLES` since the examples directory does not exist anymore.