### PR TITLE
Remove -Werror from all builds but dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,24 +31,18 @@ env:
     - ECDAA_DIR=${TRAVIS_BUILD_DIR}/ecdaa
     - SHARED_LIBS=ON
     - XTT_INSTALL_DIR=${TRAVIS_BUILD_DIR}/install
-    - XTT_BUILD_DIR=${TRAVIS_BUILD_DIR}/build
 
 before_script:
   - .travis/install-libsodium.sh ${LIBSODIUM_TAG} ${LIBSODIUM_DIR}
   - .travis/install-xaptum-tpm.sh ${XAPTUM_TPM_TAG} ${XAPTUM_TPM_DIR}
   - .travis/install-amcl.sh ${AMCL_TAG} ${AMCL_DIR} ${AMCL_CURVES}
   - .travis/install-ecdaa.sh ${ECDAA_TAG} ${ECDAA_DIR}
-  - mkdir -p ${XTT_BUILD_DIR}
   - mkdir -p ${XTT_INSTALL_DIR}
-  - pushd ${XTT_BUILD_DIR}
   - cmake . -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DCMAKE_INSTALL_PREFIX=${XTT_INSTALL_DIR} -DBUILD_SHARED_LIBS=${SHARED_LIBS}
-  - popd
 
 script:
-  - pushd ${XTT_BUILD_DIR}
   - cmake --build . --target install -- -j2
   - ctest -E tpm -VV
-  - popd
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,21 +31,35 @@ env:
     - ECDAA_DIR=${TRAVIS_BUILD_DIR}/ecdaa
     - SHARED_LIBS=ON
     - XTT_INSTALL_DIR=${TRAVIS_BUILD_DIR}/install
+    - XTT_BUILD_DIR=${TRAVIS_BUILD_DIR}/build
 
 before_script:
   - .travis/install-libsodium.sh ${LIBSODIUM_TAG} ${LIBSODIUM_DIR}
   - .travis/install-xaptum-tpm.sh ${XAPTUM_TPM_TAG} ${XAPTUM_TPM_DIR}
   - .travis/install-amcl.sh ${AMCL_TAG} ${AMCL_DIR} ${AMCL_CURVES}
   - .travis/install-ecdaa.sh ${ECDAA_TAG} ${ECDAA_DIR}
+  - mkdir -p ${XTT_BUILD_DIR}
   - mkdir -p ${XTT_INSTALL_DIR}
+  - pushd ${XTT_BUILD_DIR}
   - cmake . -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DCMAKE_INSTALL_PREFIX=${XTT_INSTALL_DIR} -DBUILD_SHARED_LIBS=${SHARED_LIBS}
+  - popd
 
 script:
+  - pushd ${XTT_BUILD_DIR}
   - cmake --build . --target install -- -j2
   - ctest -E tpm -VV
+  - popd
 
 matrix:
   include:
+    - name: "Dev build, gcc"
+      env:
+        - TYPE=DEV
+        - BUILD_TYPE=Dev
+    - name: "DevDebug build, gcc"
+      env:
+        - TYPE=DEBUG
+        - BUILD_TYPE=DevDebug
     - name: "Release build, gcc"
       env:
         - TYPE=RELEASE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,8 +36,10 @@ if(NOT DEFINED BUILD_SHARED_LIBS OR NOT  "${BUILD_SHARED_LIBS}")
   set(BUILD_STATIC_LIBS ON CACHE BOOL "Build as a static library" FORCE)
 endif()
 
-add_compile_options(-std=c99 -Werror -Wall -Wextra -Wno-missing-field-initializers)
+add_compile_options(-std=c99 -Wall -Wextra -Wno-missing-field-initializers)
 set(CMAKE_C_FLAGS_RELWITHSANITIZE "${CMAKE_C_FLAGS_RELWITHSANITIZE} -O2 -g -fsanitize=address,undefined -fsanitize=unsigned-integer-overflow")
+set(CMAKE_C_FLAGS_DEV "${CMAKE_C_FLAGS_RELEASE} -Werror")
+set(CMAKE_C_FLAGS_DEVDEBUG "${CMAKE_C_FLAGS_DEBUG} -Werror")
 
 set(XTT_SRCS
         src/libsodium_wrapper.c

--- a/README.md
+++ b/README.md
@@ -72,18 +72,20 @@ ctest -V
 
 The following CMake configuration options are supported.
 
-| Option               | Values         | Default    | Description                                |
-|----------------------|----------------|------------|--------------------------------------------|
-| CMAKE_BUILD_TYPE     | Release        |            | With full optimizations.                   |
-|                      | Debug          |            | With debug symbols.                        |
-|                      | RelWithDebInfo |            | With full optimizations and debug symbols. |
-| CMAKE_INSTALL_PREFIX | <string>       | /usr/local | The directory to install the library in.   |
-| USE_TPM              | ON, OFF        | ON         | Build with support for using a TPM 2.0     |
-| BUILD_TOOL           | ON, OFF        | ON         | Build tool.                                |
-| BUILD_SHARED_LIBS    | ON, OFF        | ON         | Build shared libraries.                    |
-| BUILD_STATIC_LIBS    | ON, OFF        | OFF        | Build static libraries.                    |
-| BUILD_TESTING        | ON, OFF        | ON         | Build the test suite.                      |
-| STATIC_SUFFIX        | <string>       | <none>     | Appends a suffix to the static lib name.   |
+| Option               | Values         | Default    | Description                                            |
+|----------------------|----------------|------------|--------------------------------------------------------|
+| CMAKE_BUILD_TYPE     | Release        |            | With full optimizations.                               |
+|                      | Debug          |            | With debug symbols.                                    |
+|                      | RelWithDebInfo |            | With full optimizations and debug symbols.             |
+|                      | Dev            |            | With warnings treated as errors and full optimizations.|
+|                      | DevDebug       |            | With warnings treated as errors and debug symbols.     |
+| CMAKE_INSTALL_PREFIX |                | /usr/local | The directory to install the library in.               |
+| USE_TPM              | ON, OFF        | ON         | Build with support for using a TPM 2.0                 |
+| BUILD_TOOL           | ON, OFF        | ON         | Build tool.                                            |
+| BUILD_SHARED_LIBS    | ON, OFF        | ON         | Build shared libraries.                                |
+| BUILD_STATIC_LIBS    | ON, OFF        | OFF        | Build static libraries.                                |
+| BUILD_TESTING        | ON, OFF        | ON         | Build the test suite.                                  |
+| STATIC_SUFFIX        | <string>       | <none>     | Appends a suffix to the static lib name.               |
 
 ### Installing
 
@@ -107,7 +109,7 @@ To create root configuration data, run:
 ### Provisioning a Server        
 To create server configuration data under that root, run:  
 `xtt genkey -v server_priv.bin -b server_pub.bin` to create a server key pair.  
-`xtt genservercert -s <server id file>` to create a server certificate. 
+`xtt genservercert` to create a server certificate.
 
 ### Running a Test Server  
 The server executable can take the DAA Group Public Key and basename to use as parameter:  
@@ -124,7 +126,7 @@ and output the agreed-upon identity information exchanged with the client.
 The client executable can take the server's ID, DAA group public key, credentials, secret key, and basename to use as parameter:  
 (run `xtt runclient -h` for a full help on all available parameters):
 ```bash
-xtt runclient -r <server id file> -d <gpk file> -c <credential file> -k <secret key file> -n <basename file>
+xtt runclient -d <gpk file> -c <credential file> -k <secret key file> -n <basename file>
 ```
 
 The client will then initiate an identity-provisioning handshake with the server


### PR DESCRIPTION
This adds Dev and DevDebug build types, which use `-Werror`, to Travis-CI and removes `-Werror` from the Release, RelWithDebInfo, and Debug builds.

Fixes #69 