### PR TITLE
Re-organize TPM context structure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,16 +59,21 @@ set(XTT_SRCS
         src/util/generate_x509_certificate.c
         src/util/wrap_keys_asn1.c
         src/util/internal/asn1.c
-        src/util/tpm_context.c
         src/internal/byte_utils.c
         src/internal/key_derivation.c
         src/internal/crypto_utils.c
         src/internal/message_utils.c
         src/internal/server_cookie.c
         src/internal/signatures.c
+        )
+
+if(USE_TPM)
+  list(APPEND XTT_SRCS
+        src/tpm/context.c
         src/tpm/handles.c
         src/tpm/nvram.c
         )
+endif()
 
 ################################################################################
 # Shared Libary

--- a/include/xtt.h
+++ b/include/xtt.h
@@ -36,7 +36,11 @@
 #include <xtt/util/generate_server_certificate.h>
 #include <xtt/util/file_io.h>
 #include <xtt/util/util_errors.h>
+
+#ifdef USE_TPM
+#include <xtt/tpm/context.h>
 #include <xtt/tpm/handles.h>
 #include <xtt/tpm/nvram.h>
+#endif
 
 #endif

--- a/include/xtt/tpm/context.h
+++ b/include/xtt/tpm/context.h
@@ -25,18 +25,30 @@ extern "C" {
 #endif
 
 #include <tss2/tss2_sys.h>
-#include <tss2/tss2_tcti_socket.h>
-#include <tss2/tss2_tcti_device.h>
+#include <tss2/tss2_tcti.h>
 
 typedef enum {
     XTT_TCTI_SOCKET,
     XTT_TCTI_DEVICE,
 } xtt_tcti_type;
 
-int initialize_tcti(TSS2_TCTI_CONTEXT **tcti_context, xtt_tcti_type tcti_type, const char *dev_file);
+struct xtt_tpm_params {
+    xtt_tcti_type tcti;
+    const char *dev_file;
+    const char *hostname;
+    const char *port;
+};
 
-int initialize_sapi(TSS2_SYS_CONTEXT *sapi_context, size_t sapi_ctx_size, TSS2_TCTI_CONTEXT *tcti_context);
+struct xtt_tpm_context {
+    unsigned char tcti_context_buffer[256];
+    TSS2_TCTI_CONTEXT *tcti_context;
+    unsigned char sapi_context_buffer[5120];
+    TSS2_SYS_CONTEXT *sapi_context;
+};
 
+int xtt_init_tpm_context(struct xtt_tpm_context *ctx, const struct xtt_tpm_params *params);
+
+void xtt_free_tpm_context(struct xtt_tpm_context *ctx);
 
 #ifdef __cplusplus
 }

--- a/include/xtt/tpm/context.h
+++ b/include/xtt/tpm/context.h
@@ -16,8 +16,8 @@
  *
  *****************************************************************************/
 
-#ifndef XTT_UTIL_TPM_CONTEXT_H
-#define XTT_UTIL_TPM_CONTEXT_H
+#ifndef XTT_TPM_CONTEXT_H
+#define XTT_TPM_CONTEXT_H
 #pragma once
 
 #ifdef __cplusplus

--- a/include/xtt/tpm/nvram.h
+++ b/include/xtt/tpm/nvram.h
@@ -20,7 +20,7 @@
 #define XTT_TPM_NVRAM_H
 #pragma once
 
-#include <tss2/tss2_sys.h>
+#include <xtt/tpm/context.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -37,21 +37,21 @@ enum xtt_object_name {
 
 TSS2_RC
 xtt_read_object(unsigned char* out_buffer,
-                 uint16_t out_buffer_size,
-                 uint16_t *out_length,
-                 enum xtt_object_name object_name,
-                 TSS2_SYS_CONTEXT *sapi_context);
+                uint16_t out_buffer_size,
+                uint16_t *out_length,
+                enum xtt_object_name object_name,
+                struct xtt_tpm_context *tpm_ctx);
 
 TSS2_RC
 xtt_read_nvram(unsigned char *out,
-                uint16_t size,
-                TPM_HANDLE index,
-                TSS2_SYS_CONTEXT *sapi_context);
+               uint16_t size,
+               TPM_HANDLE index,
+               struct xtt_tpm_context *tpm_ctx);
 
 TSS2_RC
 xtt_get_nvram_size(uint16_t *size_out,
-                    TPM_HANDLE index,
-                    TSS2_SYS_CONTEXT *sapi_context);
+                   TPM_HANDLE index,
+                   struct xtt_tpm_context *tpm_ctx);
 
 #ifdef __cplusplus
 }

--- a/src/tpm/context.c
+++ b/src/tpm/context.c
@@ -21,7 +21,7 @@
  #include <assert.h>
 
  #include <xtt/util/util_errors.h>
- #include <xtt/util/tpm_context.h>
+ #include <xtt/tpm/context.h>
 
  const char *tpm_hostname_g = "localhost";
  const char *tpm_port_g = "2321";

--- a/src/tpm/nvram.c
+++ b/src/tpm/nvram.c
@@ -25,10 +25,10 @@
 
 TSS2_RC
 xtt_read_object(unsigned char* out_buffer,
-                 uint16_t out_buffer_size,
-                 uint16_t *out_length,
-                 enum xtt_object_name object_name,
-                 TSS2_SYS_CONTEXT *sapi_context)
+                uint16_t out_buffer_size,
+                uint16_t *out_length,
+                enum xtt_object_name object_name,
+                struct xtt_tpm_context *tpm_ctx)
 {
     TPM_HANDLE index = 0;
 
@@ -54,7 +54,7 @@ xtt_read_object(unsigned char* out_buffer,
     }
 
     uint16_t size = 0;
-    TSS2_RC ret = xtt_get_nvram_size(&size, index, sapi_context);
+    TSS2_RC ret = xtt_get_nvram_size(&size, index, tpm_ctx);
     if (TSS2_RC_SUCCESS != ret)
         return ret;
 
@@ -63,14 +63,14 @@ xtt_read_object(unsigned char* out_buffer,
 
     *out_length = size;
 
-    return xtt_read_nvram(out_buffer, size, index, sapi_context);
+    return xtt_read_nvram(out_buffer, size, index, tpm_ctx);
 }
 
 TSS2_RC
 xtt_read_nvram(unsigned char *out,
-                uint16_t size,
-                TPM_HANDLE index,
-                TSS2_SYS_CONTEXT *sapi_context)
+               uint16_t size,
+               TPM_HANDLE index,
+               struct xtt_tpm_context *tpm_ctx)
 {
     TSS2_RC ret = TSS2_RC_SUCCESS;
 
@@ -102,7 +102,7 @@ xtt_read_nvram(unsigned char *out,
 
         TPM2B_MAX_NV_BUFFER nv_data = {.size=0};
 
-        ret = Tss2_Sys_NV_Read(sapi_context,
+        ret = Tss2_Sys_NV_Read(tpm_ctx->sapi_context,
                                index,
                                index,
                                &sessionsData,
@@ -126,8 +126,8 @@ xtt_read_nvram(unsigned char *out,
 
 TSS2_RC
 xtt_get_nvram_size(uint16_t *size_out,
-                    TPM_HANDLE index,
-                    TSS2_SYS_CONTEXT *sapi_context)
+                   TPM_HANDLE index,
+                   struct xtt_tpm_context *tpm_ctx)
 {
     TSS2_SYS_CMD_AUTHS sessionsData = {.cmdAuthsCount = 0};
     TSS2_SYS_RSP_AUTHS sessionsDataOut = {.rspAuthsCount = 0};
@@ -136,7 +136,7 @@ xtt_get_nvram_size(uint16_t *size_out,
 
     TPM2B_NAME nv_name = {0};
 
-    TSS2_RC rval = Tss2_Sys_NV_ReadPublic(sapi_context,
+    TSS2_RC rval = Tss2_Sys_NV_ReadPublic(tpm_ctx->sapi_context,
                                           index,
                                           &sessionsData,
                                           &nv_public,

--- a/tool/client.c
+++ b/tool/client.c
@@ -315,7 +315,7 @@ int read_in_from_TPM(struct xtt_tpm_context *tpm_ctx,
                                *basename_len,
                                &length_read,
                                XTT_BASENAME,
-                               tpm_ctx->sapi_context);
+                               tpm_ctx);
     if (0 != nvram_ret) {
         fprintf(stderr, "Error reading basename from TPM NVRAM\n");
         return nvram_ret;
@@ -327,7 +327,7 @@ int read_in_from_TPM(struct xtt_tpm_context *tpm_ctx,
                                 sizeof(xtt_daa_group_pub_key_lrsw),
                                 &length_read,
                                 XTT_GROUP_PUBLIC_KEY,
-                                tpm_ctx->sapi_context);
+                                tpm_ctx);
     if (0 != nvram_ret) {
         fprintf(stderr, "Error reading GPK from TPM NVRAM");
         return TPM_ERROR;
@@ -338,7 +338,7 @@ int read_in_from_TPM(struct xtt_tpm_context *tpm_ctx,
                                 sizeof(xtt_daa_credential_lrsw),
                                 &length_read,
                                 XTT_CREDENTIAL,
-                                tpm_ctx->sapi_context);
+                                tpm_ctx);
     if (0 != nvram_ret) {
         fprintf(stderr, "Error reading credential from TPM NVRAM");
         return TPM_ERROR;
@@ -349,7 +349,7 @@ int read_in_from_TPM(struct xtt_tpm_context *tpm_ctx,
                                 sizeof(xtt_root_certificate),
                                 &length_read,
                                 XTT_ROOT_XTT_CERTIFICATE,
-                                tpm_ctx->sapi_context);
+                                tpm_ctx);
     if (0 != nvram_ret) {
         fprintf(stderr, "Error reading root's certificate from TPM NVRAM");
         return TPM_ERROR;

--- a/tool/parse_cli.h
+++ b/tool/parse_cli.h
@@ -25,7 +25,11 @@ extern "C" {
 #endif
 
 #include <stdbool.h>
+
+#ifdef USE_TPM
+#include <xtt/tpm/context.h>
 #include <xtt/tpm/nvram.h>
+#endif
 
 typedef enum {
     action_genkey,
@@ -58,20 +62,20 @@ struct cli_params {
     const char* portstr;
     unsigned short port;
     bool usetpm;
-    const char* tcti;
     const char* suitespec;
     const char* serverhost;
-    const char* devfile;
     const char* daacred;
     const char* daasecretkey;
     const char* requestid;
     const char* longtermcert;
     const char* longtermpriv;
     const char* assignedid;
-    const char* tpmhostname;
-    const char* tpmport;
     const char* outfile;
+
+#ifdef USE_TPM
+    struct xtt_tpm_params tpm_params;
     enum xtt_object_name obj_name;
+#endif
 
 };
 

--- a/tool/read_nvram.c
+++ b/tool/read_nvram.c
@@ -16,127 +16,41 @@
  *
  *****************************************************************************/
 
- #include <tss2/tss2_tcti_device.h>
-#include <tss2/tss2_tcti_socket.h>
+#include "read_nvram.h"
+
+#include <xtt/tpm/context.h>
 #include <xtt/tpm/nvram.h>
 #include <xtt/util/util_errors.h>
 #include <xtt/util/file_io.h>
-#include <xtt/util/tpm_context.h>
 
-#include <getopt.h>
-
-#include <stdlib.h>
-#include <string.h>
 #include <stdio.h>
-
-#include "read_nvram.h"
 
 #define MAX_NVRAM_SIZE 768
 
-struct nvram_context {
-    xtt_tcti_type tcti;
-    const char *tpm_dev_file;
-    const char *tpm_hostname;
-    const char *tpm_port;
-    const char *out_filename;
-    enum xtt_object_name obj_name;
-    unsigned char tcti_context_buffer[256];
-    TSS2_TCTI_CONTEXT *tcti_context;
-    unsigned char sapi_context_buffer[5120];
-    TSS2_SYS_CONTEXT *sapi_context;
-};
-
-static
-void
-init_device_tcti(struct nvram_context *ctx);
-
-static
-void
-init_socket_tcti(struct nvram_context *ctx);
-
-int read_nvram(const char* tcti_str, const char* devfile, const char* tpmhostname,
-               const char* tpmport, const char* outfile, enum xtt_object_name obj_name)
+int read_nvram(const struct xtt_tpm_params *params, const char* outfile, enum xtt_object_name obj_name)
 {
-    struct nvram_context ctx;
+    struct xtt_tpm_context ctx;
 
-    if (0 == strcmp(tcti_str, "device")) {
-        ctx.tcti = XTT_TCTI_DEVICE;
-    } else if (0 == strcmp(tcti_str, "socket")) {
-        ctx.tcti = XTT_TCTI_SOCKET;
-    } else {
-        fprintf(stderr, "Unknown tcti_type '%s'\n", tcti_str);
-        return TPM_ERROR;
+    int ctx_ret = xtt_init_tpm_context(&ctx, params);
+    if (SUCCESS != ctx_ret) {
+        fprintf(stderr, "Error initializing TPM context: %d\n", ctx_ret);
+        return ctx_ret;
     }
 
-    ctx.tpm_dev_file = devfile;
-    ctx.tpm_hostname = tpmhostname;
-    ctx.tpm_port = tpmport;
-    ctx.out_filename = outfile;
-    ctx.obj_name = obj_name;
-
-    switch (ctx.tcti) {
-        case XTT_TCTI_DEVICE:
-            init_device_tcti(&ctx);
-            break;
-        case XTT_TCTI_SOCKET:
-            init_socket_tcti(&ctx);
-    }
-
-    size_t sapi_ctx_size = Tss2_Sys_GetContextSize(0);
-    ctx.sapi_context = malloc(sapi_ctx_size);
-
-    initialize_sapi(ctx.sapi_context, sapi_ctx_size, ctx.tcti_context);
     unsigned char output_data[MAX_NVRAM_SIZE];
     uint16_t output_length;
     printf("Reading object from NVRAM...");
-    TSS2_RC read_ret = xtt_read_object(output_data, sizeof(output_data), &output_length, ctx.obj_name, ctx.sapi_context);
+    TSS2_RC read_ret = xtt_read_object(output_data, sizeof(output_data), &output_length, obj_name, ctx.sapi_context);
     if (TSS2_RC_SUCCESS != read_ret) {
         fprintf(stderr, "Bad read_ret: %#X\n", read_ret);
         return TPM_ERROR;
     }
-    free(ctx.sapi_context);
 
-    xtt_save_to_file(output_data, (size_t)output_length, ctx.out_filename);
+    xtt_save_to_file(output_data, (size_t)output_length, outfile);
 
-    Tss2_Sys_Finalize(ctx.sapi_context);
-    tss2_tcti_finalize(ctx.tcti_context);
+    xtt_free_tpm_context(&ctx);
 
     printf("\tok\n");
-    return 0;
+    return SUCCESS;
 }
 
-void
-init_device_tcti(struct nvram_context *ctx)
-{
-    TSS2_RC ret = TSS2_RC_SUCCESS;
-
-    if (tss2_tcti_getsize_device() >= sizeof(ctx->tcti_context_buffer)) {
-        fprintf(stderr, "TCTI device context larger than allocated buffer\n");
-        exit(1);
-    }
-    ctx->tcti_context = (TSS2_TCTI_CONTEXT*)ctx->tcti_context_buffer;
-
-    ret = tss2_tcti_init_device(ctx->tpm_dev_file, strlen(ctx->tpm_dev_file), ctx->tcti_context);
-    if (TSS2_RC_SUCCESS != ret) {
-        fprintf(stderr, "Error initializing TCTI device\n");
-        exit(1);
-    }
-}
-
-void
-init_socket_tcti(struct nvram_context *ctx)
-{
-    TSS2_RC ret = TSS2_RC_SUCCESS;
-
-    if (tss2_tcti_getsize_socket() >= sizeof(ctx->tcti_context_buffer)) {
-        fprintf(stderr, "TCTI socket context larger than allocated buffer\n");
-        exit(1);
-    }
-    ctx->tcti_context = (TSS2_TCTI_CONTEXT*)ctx->tcti_context_buffer;
-
-    ret = tss2_tcti_init_socket(ctx->tpm_hostname, ctx->tpm_port, ctx->tcti_context);
-    if (TSS2_RC_SUCCESS != ret) {
-        fprintf(stderr, "Error initializing TCTI socket\n");
-        exit(1);
-    }
-}

--- a/tool/read_nvram.c
+++ b/tool/read_nvram.c
@@ -40,7 +40,7 @@ int read_nvram(const struct xtt_tpm_params *params, const char* outfile, enum xt
     unsigned char output_data[MAX_NVRAM_SIZE];
     uint16_t output_length;
     printf("Reading object from NVRAM...");
-    TSS2_RC read_ret = xtt_read_object(output_data, sizeof(output_data), &output_length, obj_name, ctx.sapi_context);
+    TSS2_RC read_ret = xtt_read_object(output_data, sizeof(output_data), &output_length, obj_name, &ctx);
     if (TSS2_RC_SUCCESS != read_ret) {
         fprintf(stderr, "Bad read_ret: %#X\n", read_ret);
         return TPM_ERROR;

--- a/tool/read_nvram.h
+++ b/tool/read_nvram.h
@@ -25,11 +25,9 @@ extern "C" {
 #endif
 
 #include <xtt/tpm/nvram.h>
+#include <xtt/tpm/context.h>
 
-
-int read_nvram(const char* tcti_str, const char* devfile, const char* tpmhostname,
-               const char* tpmport, const char* outfile, enum xtt_object_name obj_name);
-
+int read_nvram(const struct xtt_tpm_params *params, const char* outfile, enum xtt_object_name obj_name);
 
 
 #ifdef __cplusplus


### PR DESCRIPTION
This series:
- Moves the TPM context files from under the `util` namespace into the `tpm` namespace
- Moves the TPM context buffers (the raw memory for the TCTI/SAPI contexts) into the TPM context, and uses that structure to manage the memory (via `init` and `free` functions for the `xtt_tpm_context` object)
- Includes `USE_TPM` in more parts of the tool, to ensure the tool still builds even with `USE_TPM=OFF` (and that its help messages are still helpful in that case, too)