### PR TITLE
cmake: Require xaptum-tpm v0.5.7 or higher.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ env:
     - LIBSODIUM_DIR=${TRAVIS_BUILD_DIR}/libsodium
     - AMCL_TAG=4.7.0
     - AMCL_DIR=${TRAVIS_BUILD_DIR}/milagro-crypto-c/install
-    - XAPTUM_TPM_TAG=v0.5.7
+    - XAPTUM_TPM_TAG=v0.5.8
     - XAPTUM_TPM_DIR=${TRAVIS_BUILD_DIR}/xaptum-tpm/
     - AMCL_CURVES=FP256BN,NIST256
     - ECDAA_TAG=v0.10.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ find_package(sodium 1.0.11 REQUIRED QUIET)
 
 if(USE_TPM)
         add_definitions(-DUSE_TPM)
-        find_package(xaptum-tpm 0.5.0 REQUIRED QUIET)
+        find_package(xaptum-tpm 0.5.7 REQUIRED QUIET)
         find_package(ecdaa 0.10.0 COMPONENTS tpm REQUIRED QUIET)
 endif()
 


### PR DESCRIPTION
The use of xaptum-tpm's new NVRAM functionality requires we use v0.5.7 or greater, not 0.5.6.

fixes #104 