### PR TITLE
Rename `public` in API, so C++ compilers won't complain

### DIFF
--- a/include/xtt/crypto/kx.h
+++ b/include/xtt/crypto/kx.h
@@ -91,18 +91,18 @@ struct xtt_crypto_kx_shared {
 /**
  * Set the value of a :xtt_crypto_kx_public: key.
  *
- * @public the public key to set
+ * @public_key the public key to set
  * @buf the buffer holding the value
  * @buflen the size in bytes of value
  */
 inline static
 void
-xtt_crypto_kx_public_set(struct xtt_crypto_kx_public* public,
+xtt_crypto_kx_public_set(struct xtt_crypto_kx_public* public_key,
                          unsigned char* buf,
                          uint16_t buflen)
 {
-    public->len = buflen;
-    memcpy(&public->buf, buf, public->len);
+    public_key->len = buflen;
+    memcpy(&public_key->buf, buf, public_key->len);
 }
 
 /**
@@ -122,11 +122,11 @@ struct xtt_crypto_kx_ops {
     /**
      * Generates a new key pair.
      *
-     * @public the destination for the generated public key
-     * @secret the destination for the generated secret key
+     * @public_key the destination for the generated public key
+     * @secret_key the destination for the generated secret key
      */
-    int (*keypair)(struct xtt_crypto_kx_public* public,
-                   struct xtt_crypto_kx_secret* secret);
+    int (*keypair)(struct xtt_crypto_kx_public* public_key,
+                   struct xtt_crypto_kx_secret* secret_key);
 
     /**
      * Computes the shared secret.

--- a/include/xtt/crypto_wrapper.h
+++ b/include/xtt/crypto_wrapper.h
@@ -35,8 +35,8 @@ void xtt_crypto_secure_clear(unsigned char* memory, uint16_t memory_length);
 
 void xtt_crypto_get_random(unsigned char* buffer, uint16_t buffer_length);
 
-int xtt_crypto_kx_x25519_keypair(struct xtt_crypto_kx_public* public,
-                                 struct xtt_crypto_kx_secret* secret);
+int xtt_crypto_kx_x25519_keypair(struct xtt_crypto_kx_public* public_key,
+                                 struct xtt_crypto_kx_secret* secret_key);
 
 int xtt_crypto_kx_x25519_exchange(struct xtt_crypto_kx_shared* shared,
                                   const struct xtt_crypto_kx_public* other_public,

--- a/src/libsodium_wrapper.c
+++ b/src/libsodium_wrapper.c
@@ -81,14 +81,14 @@ void xtt_crypto_get_random(unsigned char* buffer, uint16_t buffer_length)
     randombytes_buf(buffer, buffer_length);
 }
 
-int xtt_crypto_kx_x25519_keypair(struct xtt_crypto_kx_public* public,
-                                 struct xtt_crypto_kx_secret* secret)
+int xtt_crypto_kx_x25519_keypair(struct xtt_crypto_kx_public* public_key,
+                                 struct xtt_crypto_kx_secret* secret_key)
 {
-    public->len = sizeof(xtt_crypto_x25519_public);
-    secret->len = sizeof(xtt_crypto_x25519_secret);
+    public_key->len = sizeof(xtt_crypto_x25519_public);
+    secret_key->len = sizeof(xtt_crypto_x25519_secret);
 
-    randombytes_buf(&secret->buf, secret->len);
-    return crypto_scalarmult_base(&public->buf, &secret->buf);
+    randombytes_buf(&secret_key->buf, secret_key->len);
+    return crypto_scalarmult_base(&public_key->buf, &secret_key->buf);
 }
 
 int xtt_crypto_kx_x25519_exchange(struct xtt_crypto_kx_shared* shared,

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -52,3 +52,5 @@ add_test(NAME "tool_test"
   ${PROJECT_SOURCE_DIR}/data/client
   ${CURRENT_TEST_BINARY_DIR}
   )
+
+add_subdirectory(cpp)

--- a/test/cpp/CMakeLists.txt
+++ b/test/cpp/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
+
+set(CURRENT_TEST_BINARY_DIR ${CMAKE_BINARY_DIR}/testBin/)
+
+add_executable(cpp_test cpp_test.cpp)
+
+enable_language(CXX)
+
+set_target_properties(cpp_test PROPERTIES COMPILE_OPTIONS -std=c++03)
+
+if(BUILD_SHARED_LIBS)
+  target_link_libraries(cpp_test PRIVATE xtt
+    -fsanitize=address
+    )
+else()
+  target_link_libraries(cpp_test PRIVATE xtt_static
+    -fsanitize=address
+    )
+endif()
+
+set_target_properties(cpp_test PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY ${CURRENT_TEST_BINARY_DIR}
+)
+
+add_test(NAME cpp_test 
+  COMMAND ${CURRENT_TEST_BINARY_DIR}/cpp_test
+)

--- a/test/cpp/cpp_test.cpp
+++ b/test/cpp/cpp_test.cpp
@@ -1,0 +1,9 @@
+#include <iostream>
+
+#include <xtt.h>
+
+int main()
+{
+    // Just want to make sure our headers can compile correctly using a C++ compiler
+    std::cout << "Hello\n";
+}


### PR DESCRIPTION
Because `public` is a reserved keyword in C++, we can't use that as an identifier in our public API (because we want that to be include-able in C++ projects).

This series:
- Renames the few places where `public` was used to `public_key`
- Adds a simple test executable whose purpose is to be compiled by a C++ compiler, to check that this compilation works