### PR TITLE
Add permission to `xtt_save_to_file`

### DIFF
--- a/include/xtt/util/file_io.h
+++ b/include/xtt/util/file_io.h
@@ -23,15 +23,38 @@
  extern "C" {
  #endif
 
-#include <stdio.h>
+ #include <fcntl.h>
+ #include <stddef.h>
+
+ #define KEY_PERMISSION     0600
+ #define CERT_PERMISSION    0644
+
 /*
- * Writes given byte-string to the given file.
+ * Writes given byte-string to the given file with a given permission level.
  *
  * Returns:
  * 'bytes_to_write' on success
  * SAVE_TO_FILE_ERROR on failure
 */
-int xtt_save_to_file(unsigned char *buffer, size_t bytes_to_write, const char *filename);
+int xtt_save_to_file(unsigned char *buffer, size_t bytes_to_write, const char *filename, mode_t permission);
+
+/*
+ * Wrapper for xtt_save_to_file using KEY_PERMISSION level.
+ * 
+ * Returns:
+ * 'bytes_to_write' on success
+ * SAVE_TO_FILE_ERROR on failure
+*/
+int xtt_save_key_to_file(unsigned char *buffer, size_t bytes_to_write, const char *filename);
+
+/*
+ * Wrapper for xtt_save_to_file using CERT_PERMISSION level.
+ * 
+ * Returns:
+ * 'bytes_to_write' on success
+ * SAVE_TO_FILE_ERROR on failure
+*/
+int xtt_save_cert_to_file(unsigned char *buffer, size_t bytes_to_write, const char *filename);
 
 /*
  * Read at-most `bytes_to_read` bytes from the given file.

--- a/include/xtt/util/file_io.h
+++ b/include/xtt/util/file_io.h
@@ -15,55 +15,55 @@
  *    limitations under the License
  *
  *****************************************************************************/
- #ifndef XTT_UTIL_FILE_IO_H
- #define XTT_UTIL_FILE_IO_H
- #pragma once
+#ifndef XTT_UTIL_FILE_IO_H
+#define XTT_UTIL_FILE_IO_H
+#pragma once
 
- #ifdef __cplusplus
- extern "C" {
- #endif
+#ifdef __cplusplus
+extern "C" {
+#endif
 
- #include <fcntl.h>
- #include <stddef.h>
+#include <fcntl.h>
+#include <stddef.h>
 
- #define KEY_PERMISSION     0600
- #define CERT_PERMISSION    0644
+#define KEY_PERMISSION     0600
+#define CERT_PERMISSION    0644
 
 /*
- * Writes given byte-string to the given file with a given permission level.
- *
- * Returns:
- * 'bytes_to_write' on success
- * SAVE_TO_FILE_ERROR on failure
+* Writes given byte-string to the given file with a given permission level.
+*
+* Returns:
+* 'bytes_to_write' on success
+* SAVE_TO_FILE_ERROR on failure
 */
 int xtt_save_to_file(unsigned char *buffer, size_t bytes_to_write, const char *filename, mode_t permission);
 
 /*
- * Wrapper for xtt_save_to_file using KEY_PERMISSION level.
- * 
- * Returns:
- * 'bytes_to_write' on success
- * SAVE_TO_FILE_ERROR on failure
+* Wrapper for xtt_save_to_file using KEY_PERMISSION level.
+* 
+* Returns:
+* 'bytes_to_write' on success
+* SAVE_TO_FILE_ERROR on failure
 */
 int xtt_save_key_to_file(unsigned char *buffer, size_t bytes_to_write, const char *filename);
 
 /*
- * Wrapper for xtt_save_to_file using CERT_PERMISSION level.
- * 
- * Returns:
- * 'bytes_to_write' on success
- * SAVE_TO_FILE_ERROR on failure
+* Wrapper for xtt_save_to_file using CERT_PERMISSION level.
+* 
+* Returns:
+* 'bytes_to_write' on success
+* SAVE_TO_FILE_ERROR on failure
 */
 int xtt_save_cert_to_file(unsigned char *buffer, size_t bytes_to_write, const char *filename);
 
 /*
- * Read at-most `bytes_to_read` bytes from the given file.
- *
- * Reads until `bytes_to_read` bytes have been read, or until `EOF`, whichever comes first.
- *
- * Returns:
- * Number of bytes read into `buffer` on success
- * READ_FROM_FILE_ERROR on failure
+* Read at-most `bytes_to_read` bytes from the given file.
+*
+* Reads until `bytes_to_read` bytes have been read, or until `EOF`, whichever comes first.
+*
+* Returns:
+* Number of bytes read into `buffer` on success
+* READ_FROM_FILE_ERROR on failure
 */
 int xtt_read_from_file(const char *filename, unsigned char *buffer, size_t bytes_to_read);
 

--- a/src/util/asn1.c
+++ b/src/util/asn1.c
@@ -90,7 +90,7 @@ int xtt_write_ecdsap256_keypair(xtt_ecdsap256_pub_key *pub_key, xtt_ecdsap256_pr
     memcpy(pubkey_location, pub_key->data, sizeof(xtt_ecdsap256_pub_key));
 
     // 2) Write key pair to file
-    int save_ret = xtt_save_to_file(keypair, XTT_ASN1_PRIVATE_KEY_LENGTH, keypair_file);
+    int save_ret = xtt_save_key_to_file(keypair, XTT_ASN1_PRIVATE_KEY_LENGTH, keypair_file);
     if (save_ret < 0) {
         return SAVE_TO_FILE_ERROR;
     }

--- a/src/util/file_io.c
+++ b/src/util/file_io.c
@@ -15,75 +15,75 @@
  *    limitations under the License
  *
  *****************************************************************************/
- #define _POSIX_C_SOURCE 200809L
- #include <stdint.h>
- #include <stdio.h>
- #include <unistd.h>
- #include <xtt/util/file_io.h>
- #include <xtt/util/util_errors.h>
+#define _POSIX_C_SOURCE 200809L
+#include <stdint.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <xtt/util/file_io.h>
+#include <xtt/util/util_errors.h>
 
- int xtt_save_to_file(unsigned char *buffer, size_t bytes_to_write, const char *filename, mode_t permission)
- {
-     int fd = open(filename, O_WRONLY | O_CREAT | O_CLOEXEC, permission);
-     if (fd == -1){
-        return SAVE_TO_FILE_ERROR;
-     }
+int xtt_save_to_file(unsigned char *buffer, size_t bytes_to_write, const char *filename, mode_t permission)
+{
+    int fd = open(filename, O_WRONLY | O_CREAT | O_CLOEXEC, permission);
+    if (fd == -1){
+    return SAVE_TO_FILE_ERROR;
+    }
 
-     size_t bytes_written = write(fd, buffer, bytes_to_write);
-     int ret = 0;
+    size_t bytes_written = write(fd, buffer, bytes_to_write);
+    int ret = 0;
 
-     if (bytes_to_write != bytes_written) {
-         ret = SAVE_TO_FILE_ERROR;
-         goto cleanup;
-     }
+    if (bytes_to_write != bytes_written) {
+        ret = SAVE_TO_FILE_ERROR;
+        goto cleanup;
+    }
 
-     ret = (int) bytes_written;
+    ret = (int) bytes_written;
 
 cleanup:
-     if (-1 == close(fd)) {
-        return SAVE_TO_FILE_ERROR;
-     }
-     return ret;
- }
+    if (-1 == close(fd)) {
+    return SAVE_TO_FILE_ERROR;
+    }
+    return ret;
+}
 
- int xtt_save_key_to_file(unsigned char *buffer, size_t bytes_to_write, const char *filename)
- {
-     return xtt_save_to_file(buffer, bytes_to_write, filename, KEY_PERMISSION);
- }
+int xtt_save_key_to_file(unsigned char *buffer, size_t bytes_to_write, const char *filename)
+{
+    return xtt_save_to_file(buffer, bytes_to_write, filename, KEY_PERMISSION);
+}
 
- int xtt_save_cert_to_file(unsigned char *buffer, size_t bytes_to_write, const char *filename)
- { 
-     return xtt_save_to_file(buffer, bytes_to_write, filename, CERT_PERMISSION);
- }
+int xtt_save_cert_to_file(unsigned char *buffer, size_t bytes_to_write, const char *filename)
+{ 
+    return xtt_save_to_file(buffer, bytes_to_write, filename, CERT_PERMISSION);
+}
 
- int xtt_read_from_file(const char *filename, unsigned char *buffer, size_t bytes_to_read)
- {
-     FILE *file_ptr = fopen(filename, "rb");
-     int ret = 0;
-     int close_ret = 0;
+int xtt_read_from_file(const char *filename, unsigned char *buffer, size_t bytes_to_read)
+{
+    FILE *file_ptr = fopen(filename, "rb");
+    int ret = 0;
+    int close_ret = 0;
 
-     if (NULL == file_ptr){
-         return READ_FROM_FILE_ERROR;
-     }
-     size_t bytes_read = fread(buffer, 1, bytes_to_read, file_ptr);
-     if (bytes_to_read != bytes_read && !feof(file_ptr)) {
+    if (NULL == file_ptr){
+        return READ_FROM_FILE_ERROR;
+    }
+    size_t bytes_read = fread(buffer, 1, bytes_to_read, file_ptr);
+    if (bytes_to_read != bytes_read && !feof(file_ptr)) {
+    ret = READ_FROM_FILE_ERROR;
+    goto cleanup;
+    }
+
+    fgetc(file_ptr);
+    if(!feof(file_ptr)){
         ret = READ_FROM_FILE_ERROR;
         goto cleanup;
-     }
+    }
 
-     fgetc(file_ptr);
-     if(!feof(file_ptr)){
-         ret = READ_FROM_FILE_ERROR;
-         goto cleanup;
-     }
-
-     ret = (int)bytes_read;
+    ret = (int)bytes_read;
 
 cleanup:
-     close_ret = fclose(file_ptr);
-     if (0 != close_ret) {
-         ret = READ_FROM_FILE_ERROR;
-     }
-     return ret;
+    close_ret = fclose(file_ptr);
+    if (0 != close_ret) {
+        ret = READ_FROM_FILE_ERROR;
+    }
+    return ret;
 
- }
+}

--- a/src/util/generate_server_certificate.c
+++ b/src/util/generate_server_certificate.c
@@ -83,7 +83,7 @@ int xtt_generate_server_certificate(const char* root_cert_file, const char* root
         return CERT_CREATION_ERROR;
     }
 
-    write_ret = xtt_save_to_file(serialized_certificate, XTT_SERVER_CERTIFICATE_ECDSAP256_LENGTH, server_certificate_filename);
+    write_ret = xtt_save_cert_to_file(serialized_certificate, XTT_SERVER_CERTIFICATE_ECDSAP256_LENGTH, server_certificate_filename);
     if(write_ret < 0){
         return SAVE_TO_FILE_ERROR;
     }

--- a/src/util/generate_x509_certificate.c
+++ b/src/util/generate_x509_certificate.c
@@ -55,7 +55,7 @@ int xtt_generate_x509_certificate(const char *keypair_filename, const char *id_f
         return CERT_CREATION_ERROR;
     }
 
-    write_ret = xtt_save_to_file(cert_buf, sizeof(cert_buf), certificate_filename);
+    write_ret = xtt_save_cert_to_file(cert_buf, sizeof(cert_buf), certificate_filename);
     if (write_ret < 0) {
         return SAVE_TO_FILE_ERROR;
     }

--- a/src/util/root.c
+++ b/src/util/root.c
@@ -62,7 +62,7 @@ int xtt_generate_root(const char *keypair_filename, const char *id_filename, con
 
     // 4) Save info to files
 
-    int write_ret = xtt_save_to_file(root_certificate.data, sizeof(xtt_root_certificate), cert_filename);
+    int write_ret = xtt_save_cert_to_file(root_certificate.data, sizeof(xtt_root_certificate), cert_filename);
     if(write_ret < 0){
         return SAVE_TO_FILE_ERROR;
     }

--- a/tool/client.c
+++ b/tool/client.c
@@ -666,7 +666,7 @@ int report_results_client(xtt_identity_type *requested_client_id,
         return 1;
     }
     printf("Server assigned me id: %s\n", my_assigned_id_as_string.data);
-    write_ret = xtt_save_to_file((unsigned char*)my_assigned_id_as_string.data, sizeof(xtt_identity_string), assigned_client_id_out_file);
+    write_ret = xtt_save_to_file((unsigned char*)my_assigned_id_as_string.data, sizeof(xtt_identity_string), assigned_client_id_out_file, 0644);
     if(write_ret < 0) {
         return SAVE_TO_FILE_ERROR;
     }
@@ -709,7 +709,7 @@ int report_results_client(xtt_identity_type *requested_client_id,
         fprintf(stderr, "Error creating X509 certificate\n");
         return CERT_CREATION_ERROR;
     }
-    write_ret = xtt_save_to_file(cert_buf, sizeof(cert_buf), longterm_public_key_out_file);
+    write_ret = xtt_save_to_file(cert_buf, sizeof(cert_buf), longterm_public_key_out_file, 0644);
     if(write_ret < 0){
         return SAVE_TO_FILE_ERROR;
     }

--- a/tool/read_nvram.c
+++ b/tool/read_nvram.c
@@ -46,11 +46,10 @@ int read_nvram(const struct xtt_tpm_params *params, const char* outfile, enum xt
         return TPM_ERROR;
     }
 
-    xtt_save_to_file(output_data, (size_t)output_length, outfile);
+    xtt_save_to_file(output_data, (size_t)output_length, outfile, 0644);
 
     xtt_free_tpm_context(&ctx);
 
     printf("\tok\n");
     return SUCCESS;
 }
-


### PR DESCRIPTION
Set permissions for created files, especially for the longterm certificate and private key.

Right now, the files that the tool creates also follow these permissions and files that are created when reading in from the TPM's nvram currently gives anything it reads the same permissions as a certificate (0644).

Fixes #114 

