### PR TITLE
util: Delete any existing contents of file before writing output.

### DIFF
--- a/src/util/file_io.c
+++ b/src/util/file_io.c
@@ -24,7 +24,7 @@
 
 int xtt_save_to_file(unsigned char *buffer, size_t bytes_to_write, const char *filename, mode_t permission)
 {
-    int fd = open(filename, O_WRONLY | O_CREAT | O_CLOEXEC, permission);
+    int fd = open(filename, O_WRONLY | O_CREAT | O_CLOEXEC | O_TRUNC, permission);
     if (fd == -1){
     return SAVE_TO_FILE_ERROR;
     }


### PR DESCRIPTION
This patch adds the `O_TRUNC` flag to the `open` call in `util/file_io.c`, so that any existing contents of a file will be deleted before writing the new output.

Fixes #117 
