### PR TITLE
test: Only run "tool_test" if BUILD_TOOL=ON.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -46,11 +46,13 @@ add_test_case("wrapper_sanity-test.c" "")
 add_test_case("integration_test.c" "1;2;3;4")
 add_test_case("certificate_test.c" "")
 
-add_test(NAME "tool_test"
-  COMMAND ${CMAKE_CURRENT_LIST_DIR}/tool-test.sh
-  ${CMAKE_BINARY_DIR}/tool
-  ${PROJECT_SOURCE_DIR}/data/client
-  ${CURRENT_TEST_BINARY_DIR}
-  )
+if(BUILD_TOOL)
+  add_test(NAME "tool_test"
+    COMMAND ${CMAKE_CURRENT_LIST_DIR}/tool-test.sh
+    ${CMAKE_BINARY_DIR}/tool
+    ${PROJECT_SOURCE_DIR}/data/client
+    ${CURRENT_TEST_BINARY_DIR}
+    )
+endif()
 
 add_subdirectory(cpp)


### PR DESCRIPTION
This became a problem when using this downstream in the `xmb` project (which sets `BUILD_TOOL=OFF`, and thus then has its tests fail because the tool_test fails).