### PR TITLE
Store longterm key in TPM

### DIFF
--- a/include/xtt/context.h
+++ b/include/xtt/context.h
@@ -27,6 +27,7 @@
 #include <xtt/daa_wrapper.h>
 
 #ifdef USE_TPM
+#include <xaptum-tpm/keys.h>
 #include <tss2/tss2_sys.h>
 #endif
 
@@ -187,6 +188,17 @@ struct xtt_client_handshake_context {
     union {
         xtt_ecdsap256_priv_key ecdsap256;
     } longterm_private_key;
+
+#ifdef USE_TPM
+    TSS2_TCTI_CONTEXT *tcti_context;
+
+    TPMI_RH_HIERARCHY hierarchy;
+    char hierarchy_password[MAX_TPM_PASSWORD_LENGTH];
+    size_t hierarchy_password_length;
+
+    TPM2_HANDLE parent_handle;
+    struct xtpm_key longterm_private_key_tpm;
+#endif
 };
 
 struct xtt_server_cookie_context {
@@ -266,6 +278,22 @@ xtt_initialize_client_handshake_context(struct xtt_client_handshake_context* ctx
                                         uint16_t out_buffer_size,
                                         xtt_version version,
                                         xtt_suite_spec suite_spec);
+
+#ifdef USE_TPM
+xtt_return_code_type
+xtt_initialize_client_handshake_context_TPM(struct xtt_client_handshake_context* ctx_out,
+                                            unsigned char *in_buffer,
+                                            uint16_t in_buffer_size,
+                                            unsigned char *out_buffer,
+                                            uint16_t out_buffer_size,
+                                            xtt_version version,
+                                            xtt_suite_spec suite_spec,
+                                            TPMI_RH_HIERARCHY hierarchy,
+                                            const char *hierarchy_password,
+                                            size_t hierarchy_password_length,
+                                            TPM2_HANDLE parent_handle,
+                                            TSS2_TCTI_CONTEXT *tcti_context);
+#endif
 
 xtt_return_code_type
 xtt_initialize_server_handshake_context(struct xtt_server_handshake_context* ctx_out,

--- a/include/xtt/crypto/hmac.h
+++ b/include/xtt/crypto/hmac.h
@@ -33,6 +33,7 @@ extern "C" {
  * They are used to ensure that the :xtt_crypto_hmac: generic buffer
  * is large enough for any HMAC output.
  */
+typedef struct {unsigned char data[32];} xtt_crypto_sha256;
 typedef struct {unsigned char data[64];} xtt_crypto_sha512;
 typedef struct {unsigned char data[64];} xtt_crypto_blake2b;
 
@@ -50,6 +51,7 @@ typedef struct {unsigned char data[64];} xtt_crypto_blake2b;
 struct xtt_crypto_hmac {
     union {
         unsigned char buf;
+        xtt_crypto_sha256 sha256;
         xtt_crypto_sha512 sha512;
         xtt_crypto_blake2b blake2b;
     };

--- a/include/xtt/crypto_wrapper.h
+++ b/include/xtt/crypto_wrapper.h
@@ -42,6 +42,10 @@ int xtt_crypto_kx_x25519_exchange(struct xtt_crypto_kx_shared* shared,
                                   const struct xtt_crypto_kx_public* other_public,
                                   const struct xtt_crypto_kx_secret* my_secret);
 
+int xtt_crypto_hash_sha256(struct xtt_crypto_hmac* out,
+                           const unsigned char* in,
+                           uint16_t in_len);
+
 int xtt_crypto_hash_sha512(struct xtt_crypto_hmac* out,
                            const unsigned char* in,
                            uint16_t inlen);

--- a/include/xtt/util/asn1.h
+++ b/include/xtt/util/asn1.h
@@ -22,6 +22,10 @@
 
 #include <stddef.h>
 
+#ifdef USE_TPM
+#include <xaptum-tpm/keys.h>
+#endif
+
 #include <xtt/crypto_types.h>
 
 #ifdef __cplusplus
@@ -48,6 +52,19 @@ int xtt_x509_from_ecdsap256_keypair(const xtt_ecdsap256_pub_key *pub_key_in,
                                   const xtt_identity_type *common_name,
                                   unsigned char *certificate_out,
                                   size_t certificate_out_length);
+
+#ifdef USE_TPM
+/*
+ * Same as above, but uses a TPM signing key.
+ */
+int xtt_x509_from_ecdsap256_TPM(const xtt_ecdsap256_pub_key *pub_key_in,
+                                const struct xtpm_key *priv_key_in,
+                                TSS2_TCTI_CONTEXT *tcti_context,
+                                const xtt_identity_type *common_name,
+                                unsigned char *certificate_out,
+                                size_t certificate_out_length);
+#endif
+
 /*
  * Writes the ECDSA keypair from the keys given
  *

--- a/src/context.c
+++ b/src/context.c
@@ -30,6 +30,16 @@
 #include <string.h>
 #include <assert.h>
 
+static
+xtt_return_code_type
+initialize_client_handshake_context_common(struct xtt_client_handshake_context* ctx_out,
+                                           unsigned char *in_buffer,
+                                           uint16_t in_buffer_size,
+                                           unsigned char *out_buffer,
+                                           uint16_t out_buffer_size,
+                                           xtt_version version,
+                                           xtt_suite_spec suite_spec);
+
 xtt_return_code_type
 xtt_initialize_server_handshake_context(struct xtt_server_handshake_context* ctx_out,
                                         unsigned char *in_buffer,
@@ -112,63 +122,79 @@ xtt_initialize_client_handshake_context(struct xtt_client_handshake_context* ctx
                                         xtt_version version,
                                         xtt_suite_spec suite_spec)
 {
-    if (ctx_out == NULL)
-        return XTT_RETURN_NULL_BUFFER;
+    xtt_return_code_type common_ret = initialize_client_handshake_context_common(ctx_out,
+                                                                                 in_buffer,
+                                                                                 in_buffer_size,
+                                                                                 out_buffer,
+                                                                                 out_buffer_size,
+                                                                                 version,
+                                                                                 suite_spec);
+    if (XTT_RETURN_SUCCESS != common_ret)
+        return common_ret;
 
-    if (MAX_HANDSHAKE_SERVER_MESSAGE_LENGTH > in_buffer_size || MAX_HANDSHAKE_CLIENT_MESSAGE_LENGTH > out_buffer_size)
-        return XTT_RETURN_CONTEXT_BUFFER_OVERFLOW;
-
-    if (XTT_VERSION_ONE != version)
-        return XTT_RETURN_UNKNOWN_VERSION;
-
-    ctx_out->state = XTT_CLIENT_HANDSHAKE_STATE_START;
-
-    ctx_out->base.version = version;
-    ctx_out->base.suite_spec = suite_spec;
-    ctx_out->base.suite_ops = xtt_suite_ops_get(suite_spec);
-    if (NULL == ctx_out->base.suite_ops)
-        return XTT_RETURN_UNKNOWN_SUITE_SPEC;
-
-    ctx_out->base.in_buffer_start = in_buffer;
-    ctx_out->base.in_message_start = ctx_out->base.in_buffer_start;
-    ctx_out->base.in_end = ctx_out->base.in_buffer_start;
-    ctx_out->base.out_buffer_start = out_buffer;
-    ctx_out->base.out_message_start = ctx_out->base.out_buffer_start;
-    ctx_out->base.out_end = ctx_out->base.out_buffer_start;
-
-    xtt_crypto_hmac_init(&ctx_out->base.hash_out, ctx_out->base.suite_ops->hmac);
-    xtt_crypto_hmac_init(&ctx_out->base.inner_hash, ctx_out->base.suite_ops->hmac);
-    xtt_crypto_hmac_init(&ctx_out->base.prf_key, ctx_out->base.suite_ops->hmac);
-    xtt_crypto_hmac_init(&ctx_out->base.handshake_secret, ctx_out->base.suite_ops->hmac);
-
-    xtt_crypto_aead_key_init(&ctx_out->base.rx_key, ctx_out->base.suite_ops->aead);
-    xtt_crypto_aead_key_init(&ctx_out->base.tx_key, ctx_out->base.suite_ops->aead);
-    xtt_crypto_aead_nonce_init(&ctx_out->base.rx_iv, ctx_out->base.suite_ops->aead);
-    xtt_crypto_aead_nonce_init(&ctx_out->base.tx_iv, ctx_out->base.suite_ops->aead);
-
-    ctx_out->base.longterm_key_length = sizeof(xtt_ecdsap256_pub_key);
-    ctx_out->base.longterm_key_signature_length = sizeof(xtt_ecdsap256_signature);
-
-    ctx_out->base.tx_sequence_num = 0;
-    ctx_out->base.rx_sequence_num = 0;
-
-    ctx_out->verify_server_signature = verify_server_signature_ecdsap256;
-
-    ctx_out->copy_longterm_key = copy_longterm_key_ecdsap256;
-
-    ctx_out->compare_longterm_keys = compare_longterm_keys_ecdsap256;
     ctx_out->longterm_sign = longterm_sign_ecdsap256;
-    ctx_out->copy_in_my_pseudonym = copy_in_pseudonym_client_lrsw;
-
-    if (0 != ctx_out->base.suite_ops->kx->keypair(&ctx_out->base.kx_pubkey,
-                                                  &ctx_out->base.kx_seckey))
-        return XTT_RETURN_CRYPTO;
 
     if (0 != xtt_crypto_create_ecdsap256_key_pair(&ctx_out->longterm_key.ecdsap256, &ctx_out->longterm_private_key.ecdsap256))
         return XTT_RETURN_CRYPTO;
 
     return XTT_RETURN_SUCCESS;
 }
+
+#ifdef USE_TPM
+xtt_return_code_type
+xtt_initialize_client_handshake_context_TPM(struct xtt_client_handshake_context* ctx_out,
+                                            unsigned char *in_buffer,
+                                            uint16_t in_buffer_size,
+                                            unsigned char *out_buffer,
+                                            uint16_t out_buffer_size,
+                                            xtt_version version,
+                                            xtt_suite_spec suite_spec,
+                                            TPMI_RH_HIERARCHY hierarchy,
+                                            const char *hierarchy_password,
+                                            size_t hierarchy_password_length,
+                                            TPM2_HANDLE parent_handle,
+                                            TSS2_TCTI_CONTEXT *tcti_context)
+{
+    xtt_return_code_type common_ret = initialize_client_handshake_context_common(ctx_out,
+                                                                                 in_buffer,
+                                                                                 in_buffer_size,
+                                                                                 out_buffer,
+                                                                                 out_buffer_size,
+                                                                                 version,
+                                                                                 suite_spec);
+    if (XTT_RETURN_SUCCESS != common_ret)
+        return common_ret;
+
+    ctx_out->hierarchy = hierarchy;
+
+    if (hierarchy_password_length > sizeof(ctx_out->hierarchy_password))
+        return XTT_RETURN_BAD_INIT;
+    memcpy(ctx_out->hierarchy_password,
+           hierarchy_password,
+           hierarchy_password_length);
+    ctx_out->hierarchy_password_length = hierarchy_password_length;
+
+    ctx_out->parent_handle = parent_handle;
+
+    ctx_out->tcti_context = tcti_context;
+
+    ctx_out->longterm_sign = longterm_sign_ecdsap256TPM;
+
+    if (TSS2_RC_SUCCESS != xtpm_gen_key(ctx_out->tcti_context,
+                                        ctx_out->parent_handle,
+                                        ctx_out->hierarchy,
+                                        ctx_out->hierarchy_password,
+                                        ctx_out->hierarchy_password_length,
+                                        &ctx_out->longterm_private_key_tpm))
+        return XTT_RETURN_CRYPTO;
+
+    if (TSS2_RC_SUCCESS != xtpm_get_public_key(&ctx_out->longterm_private_key_tpm,
+                                               ctx_out->longterm_key.ecdsap256.data))
+        return XTT_RETURN_CRYPTO;
+
+    return XTT_RETURN_SUCCESS;
+}
+#endif
 
 xtt_return_code_type
 xtt_initialize_server_cookie_context(struct xtt_server_cookie_context* ctx)
@@ -411,6 +437,69 @@ xtt_get_my_pseudonym_lrsw(xtt_daa_pseudonym_lrsw *pseudonym_out,
     memcpy(pseudonym_out->data,
            handshake_context->pseudonym.lrsw.data,
            sizeof(xtt_daa_pseudonym_lrsw));
+
+    return XTT_RETURN_SUCCESS;
+}
+
+xtt_return_code_type
+initialize_client_handshake_context_common(struct xtt_client_handshake_context* ctx_out,
+                                           unsigned char *in_buffer,
+                                           uint16_t in_buffer_size,
+                                           unsigned char *out_buffer,
+                                           uint16_t out_buffer_size,
+                                           xtt_version version,
+                                           xtt_suite_spec suite_spec)
+{
+    if (ctx_out == NULL)
+        return XTT_RETURN_NULL_BUFFER;
+
+    if (MAX_HANDSHAKE_SERVER_MESSAGE_LENGTH > in_buffer_size || MAX_HANDSHAKE_CLIENT_MESSAGE_LENGTH > out_buffer_size)
+        return XTT_RETURN_CONTEXT_BUFFER_OVERFLOW;
+
+    if (XTT_VERSION_ONE != version)
+        return XTT_RETURN_UNKNOWN_VERSION;
+
+    ctx_out->state = XTT_CLIENT_HANDSHAKE_STATE_START;
+
+    ctx_out->base.version = version;
+    ctx_out->base.suite_spec = suite_spec;
+    ctx_out->base.suite_ops = xtt_suite_ops_get(suite_spec);
+    if (NULL == ctx_out->base.suite_ops)
+        return XTT_RETURN_UNKNOWN_SUITE_SPEC;
+
+    ctx_out->base.in_buffer_start = in_buffer;
+    ctx_out->base.in_message_start = ctx_out->base.in_buffer_start;
+    ctx_out->base.in_end = ctx_out->base.in_buffer_start;
+    ctx_out->base.out_buffer_start = out_buffer;
+    ctx_out->base.out_message_start = ctx_out->base.out_buffer_start;
+    ctx_out->base.out_end = ctx_out->base.out_buffer_start;
+
+    xtt_crypto_hmac_init(&ctx_out->base.hash_out, ctx_out->base.suite_ops->hmac);
+    xtt_crypto_hmac_init(&ctx_out->base.inner_hash, ctx_out->base.suite_ops->hmac);
+    xtt_crypto_hmac_init(&ctx_out->base.prf_key, ctx_out->base.suite_ops->hmac);
+    xtt_crypto_hmac_init(&ctx_out->base.handshake_secret, ctx_out->base.suite_ops->hmac);
+
+    xtt_crypto_aead_key_init(&ctx_out->base.rx_key, ctx_out->base.suite_ops->aead);
+    xtt_crypto_aead_key_init(&ctx_out->base.tx_key, ctx_out->base.suite_ops->aead);
+    xtt_crypto_aead_nonce_init(&ctx_out->base.rx_iv, ctx_out->base.suite_ops->aead);
+    xtt_crypto_aead_nonce_init(&ctx_out->base.tx_iv, ctx_out->base.suite_ops->aead);
+
+    ctx_out->base.longterm_key_length = sizeof(xtt_ecdsap256_pub_key);
+    ctx_out->base.longterm_key_signature_length = sizeof(xtt_ecdsap256_signature);
+
+    ctx_out->base.tx_sequence_num = 0;
+    ctx_out->base.rx_sequence_num = 0;
+
+    ctx_out->verify_server_signature = verify_server_signature_ecdsap256;
+
+    ctx_out->copy_longterm_key = copy_longterm_key_ecdsap256;
+
+    ctx_out->compare_longterm_keys = compare_longterm_keys_ecdsap256;
+    ctx_out->copy_in_my_pseudonym = copy_in_pseudonym_client_lrsw;
+
+    if (0 != ctx_out->base.suite_ops->kx->keypair(&ctx_out->base.kx_pubkey,
+                                                  &ctx_out->base.kx_seckey))
+        return XTT_RETURN_CRYPTO;
 
     return XTT_RETURN_SUCCESS;
 }

--- a/src/internal/crypto_utils.h
+++ b/src/internal/crypto_utils.h
@@ -59,6 +59,13 @@ int longterm_sign_ecdsap256(unsigned char *signature_out,
                           uint16_t msg_len,
                           const struct xtt_client_handshake_context *self);
 
+#ifdef USE_TPM
+int longterm_sign_ecdsap256TPM(unsigned char *signature_out,
+                               const unsigned char *msg,
+                               uint16_t msg_len,
+                               const struct xtt_client_handshake_context *self);
+#endif
+
 int verify_root_ecdsap256(const unsigned char *signature,
                         const struct xtt_server_certificate_raw_type *certificate,
                         const struct xtt_server_root_certificate_context *self);

--- a/src/libsodium_wrapper.c
+++ b/src/libsodium_wrapper.c
@@ -169,6 +169,24 @@ int xtt_crypto_aead_aes256gcm_decrypt(unsigned char* msg,
                                          &key->buf);
 }
 
+int xtt_crypto_hash_sha256(struct xtt_crypto_hmac* out,
+                           const unsigned char* in,
+                           uint16_t inlen)
+{
+    out->len = sizeof(xtt_crypto_sha256);
+
+    crypto_hash_sha256_state h;
+
+    if (0 != crypto_hash_sha256_init(&h))
+        return -1;
+    if (0 != crypto_hash_sha256_update(&h, in, inlen))
+        return -1;
+    if (0 != crypto_hash_sha256_final(&h, &out->buf))
+        return -1;
+
+    return 0;
+}
+
 int xtt_crypto_hash_sha512(struct xtt_crypto_hmac* out,
                            const unsigned char* in,
                            uint16_t inlen)

--- a/tool/client.c
+++ b/tool/client.c
@@ -70,6 +70,15 @@ static int initialize_daa(struct xtt_client_group_context *group_ctx,
                 int use_tpm,
                 struct xtt_tpm_context *tpm_ctx);
 
+static int initialize_client_ctx(struct xtt_client_handshake_context *ctx,
+                                 unsigned char *in_buffer,
+                                 size_t in_buffer_length,
+                                 unsigned char *out_buffer,
+                                 size_t out_buffer_length,
+                                 xtt_suite_spec suite_spec,
+                                 struct xtt_tpm_context *tpm_ctx,
+                                 int use_tpm);
+
 static int read_in_from_TPM(struct xtt_tpm_context *tpm_ctx,
                   unsigned char* basename,
                   uint16_t* basename_len,
@@ -102,7 +111,9 @@ static int report_results_client(xtt_identity_type *requested_client_id,
                    struct xtt_client_handshake_context *ctx,
                    const char* assigned_client_id_out_file,
                    const char* longterm_public_key_out_file,
-                   const char* longterm_private_key_out_file);
+                   const char* longterm_private_key_out_file,
+                   int use_tpm,
+                   struct xtt_tpm_context *tpm_ctx);
 
 int run_client(struct cli_params* params)
 {
@@ -221,9 +232,16 @@ int run_client(struct cli_params* params)
     unsigned char in_buffer[MAX_HANDSHAKE_SERVER_MESSAGE_LENGTH] = {0};
     unsigned char out_buffer[MAX_HANDSHAKE_CLIENT_MESSAGE_LENGTH] = {0};
     struct xtt_client_handshake_context ctx;
-    xtt_return_code_type rc = xtt_initialize_client_handshake_context(&ctx, in_buffer, sizeof(in_buffer), out_buffer, sizeof(out_buffer), version_g_client, suite_spec);
-    if (XTT_RETURN_SUCCESS != rc) {
-        fprintf(stderr, "Error initializing client handshake context: %d\n", rc);
+    ret = initialize_client_ctx(&ctx,
+                                in_buffer,
+                                sizeof(in_buffer),
+                                out_buffer,
+                                sizeof(out_buffer),
+                                suite_spec,
+                                &tpm_ctx,
+                                use_tpm);
+    if (0 != ret) {
+        fprintf(stderr, "Error initializing client handshake context\n");
         ret = CLIENT_ERROR;
         goto finish;
     }
@@ -236,7 +254,12 @@ int run_client(struct cli_params* params)
     if (0 == ret) {
     // 5) Print the results (what we and the server now agree on post-handshake)
         ret = report_results_client(&requested_client_id,
-                             &ctx, assigned_client_id_out_file, longterm_public_key_out_file, longterm_private_key_out_file);
+                                    &ctx,
+                                    assigned_client_id_out_file,
+                                    longterm_public_key_out_file,
+                                    longterm_private_key_out_file,
+                                    use_tpm,
+                                    &tpm_ctx);
         if (0 != ret){
             ret = CLIENT_ERROR;
             goto finish;
@@ -471,6 +494,55 @@ int initialize_daa(struct xtt_client_group_context *group_ctx,
     return 0;
 }
 
+static int initialize_client_ctx(struct xtt_client_handshake_context *ctx,
+                                 unsigned char *in_buffer,
+                                 size_t in_buffer_length,
+                                 unsigned char *out_buffer,
+                                 size_t out_buffer_length,
+                                 xtt_suite_spec suite_spec,
+                                 struct xtt_tpm_context *tpm_ctx,
+                                 int use_tpm)
+{
+    xtt_return_code_type rc;
+
+    if (!use_tpm) {
+        (void)tpm_ctx;
+        rc = xtt_initialize_client_handshake_context(ctx,
+                                                     in_buffer,
+                                                     in_buffer_length,
+                                                     out_buffer,
+                                                     out_buffer_length,
+                                                     version_g_client,
+                                                     suite_spec);
+    } else {
+#ifdef USE_TPM
+        // Nb. Using defaults for hierarchy and parent_handle, and not allowing hierarchy password.
+        rc = xtt_initialize_client_handshake_context_TPM(ctx,
+                                                         in_buffer,
+                                                         in_buffer_length,
+                                                         out_buffer,
+                                                         out_buffer_length,
+                                                         version_g_client,
+                                                         suite_spec,
+                                                         0,
+                                                         NULL,
+                                                         0,
+                                                         0,
+                                                         tpm_ctx->tcti_context);
+#else
+        fprintf(stderr, "Attempted to use a TPM, but not built with TPM enabled!\n");
+        return TPM_ERROR;
+#endif
+    }
+
+    if (XTT_RETURN_SUCCESS != rc){
+        printf("%s", xtt_strerror(rc));
+        return TPM_ERROR;
+    }
+
+    return 0;
+}
+
 static
 int initialize_certs(xtt_root_certificate* root_certificate)
 {
@@ -648,7 +720,9 @@ int report_results_client(xtt_identity_type *requested_client_id,
                    struct xtt_client_handshake_context *ctx,
                    const char* assigned_client_id_out_file,
                    const char* longterm_public_key_out_file,
-                   const char* longterm_private_key_out_file)
+                   const char* longterm_private_key_out_file,
+                   int use_tpm,
+                   struct xtt_tpm_context *tpm_ctx)
 {
     int write_ret = 0;
 
@@ -696,28 +770,50 @@ int report_results_client(xtt_identity_type *requested_client_id,
             printf("}\n");
         }
     }
-    xtt_ecdsap256_priv_key my_longterm_private_key = {.data = {0}};
-    if (XTT_RETURN_SUCCESS != xtt_get_my_longterm_private_key_ecdsap256(&my_longterm_private_key, ctx)) {
-        printf("Error getting my longterm private key!\n");
-        return 1;
-    }
 
     // 3) Save longterm keypair as X509 certificate and ASN.1-encoded private key
-    unsigned char cert_buf[XTT_X509_CERTIFICATE_LENGTH] = {0};
-    if (0 != xtt_x509_from_ecdsap256_keypair(&my_longterm_key, &my_longterm_private_key, &my_assigned_id, cert_buf, sizeof(cert_buf))) {
-        fprintf(stderr, "Error creating X509 certificate\n");
-        return CERT_CREATION_ERROR;
-    }
-    write_ret = xtt_save_to_file(cert_buf, sizeof(cert_buf), longterm_public_key_out_file, 0644);
-    if(write_ret < 0){
-        return SAVE_TO_FILE_ERROR;
-    }
+    if (use_tpm) {
+#ifdef USE_TPM
+        unsigned char cert_buf[XTT_X509_CERTIFICATE_LENGTH] = {0};
+        if (0 != xtt_x509_from_ecdsap256_TPM(&my_longterm_key, &ctx->longterm_private_key_tpm, tpm_ctx->tcti_context, &my_assigned_id, cert_buf, sizeof(cert_buf))) {
+            fprintf(stderr, "Error creating X509 certificate\n");
+            return CERT_CREATION_ERROR;
+        }
+        write_ret = xtt_save_to_file(cert_buf, sizeof(cert_buf), longterm_public_key_out_file, 0644);
+        if(write_ret < 0){
+            return SAVE_TO_FILE_ERROR;
+        }
 
-    if (0 != xtt_write_ecdsap256_keypair(&my_longterm_key, &my_longterm_private_key, longterm_private_key_out_file)){
-        fprintf(stderr, "Error creating ASN.1 private key\n");
-        return 1;
-    }
+        if (TSS2_RC_SUCCESS != xtpm_write_key(&ctx->longterm_private_key_tpm, longterm_private_key_out_file)) {
+            fprintf(stderr, "Error creating ASN.1 private key\n");
+            return 1;
+        }
+#else
+        fprintf(stderr, "Attempted to use a TPM, but not built with TPM enabled!\n");
+        return TPM_ERROR;
+#endif
+    } else {
+        xtt_ecdsap256_priv_key my_longterm_private_key = {.data = {0}};
+        if (XTT_RETURN_SUCCESS != xtt_get_my_longterm_private_key_ecdsap256(&my_longterm_private_key, ctx)) {
+            printf("Error getting my longterm private key!\n");
+            return 1;
+        }
 
+        unsigned char cert_buf[XTT_X509_CERTIFICATE_LENGTH] = {0};
+        if (0 != xtt_x509_from_ecdsap256_keypair(&my_longterm_key, &my_longterm_private_key, &my_assigned_id, cert_buf, sizeof(cert_buf))) {
+            fprintf(stderr, "Error creating X509 certificate\n");
+            return CERT_CREATION_ERROR;
+        }
+        write_ret = xtt_save_to_file(cert_buf, sizeof(cert_buf), longterm_public_key_out_file, 0644);
+        if(write_ret < 0){
+            return SAVE_TO_FILE_ERROR;
+        }
+
+        if (0 != xtt_write_ecdsap256_keypair(&my_longterm_key, &my_longterm_private_key, longterm_private_key_out_file)){
+            fprintf(stderr, "Error creating ASN.1 private key\n");
+            return 1;
+        }
+    }
 
     // 4) Get pseudonym
     xtt_daa_pseudonym_lrsw my_pseudonym = {.data = {0}};

--- a/tool/parse_cli.c
+++ b/tool/parse_cli.c
@@ -358,6 +358,7 @@ void parse_runclient_cli(int argc, char** argv, struct cli_params *params){
 
         {NULL, 0, NULL, 0}
     };
+    bool nondefault_priv_file = false;
     int c;
     while ((c = getopt_long(argc, argv, "p:s:a:q:d:c:k:e:n:mt:f:i:b:v:h", cli_options, NULL)) != -1) {
         switch (c) {
@@ -415,6 +416,7 @@ void parse_runclient_cli(int argc, char** argv, struct cli_params *params){
             case 'v':
             {
                 params->longtermpriv = optarg;
+                nondefault_priv_file = true;
                 break;
             }
 #ifdef USE_TPM
@@ -432,6 +434,7 @@ void parse_runclient_cli(int argc, char** argv, struct cli_params *params){
             case 't':
             case 'f':
                 printf("TPM options are not supported, because not built with TPM support.");
+                exit(1);
 #endif
             case 'h':
             printf(usage_str, argv[0], argv[1]);
@@ -440,6 +443,9 @@ void parse_runclient_cli(int argc, char** argv, struct cli_params *params){
     }
 
 #ifdef USE_TPM
+    if (!nondefault_priv_file && 1 == params->usetpm)
+        params->longtermpriv = "longterm_priv.pem";
+
     if (0 == strcmp(tcti_str, "device")) {
         params->tpm_params.tcti = XTT_TCTI_DEVICE;
     } else if (0 == strcmp(tcti_str, "socket")) {


### PR DESCRIPTION
This PR implements the TPM key storage discussed in Issue #120. The implementation here is largely that described in that issue, except that no TPM-related functions are added to `crypto_wrapper.h`; this is because the "higher-level" functions have already been provided by the new xaptum-tpm API (and I didn't see a need to provide the "wrapper" implementation-agility for xaptum-tpm that we have for the other crypto libraries).

This work also includes:
- Bringing back SHA-256 hashing in the `crypto` sub-library
  - This is needed for creating TPM ECDSA signature, though it won't be used as a hash function for the handshake
- Updating the X.509 certificate generation to allow signing using a TPM key
  - My plan had been to actually rip out the X.509 stuff, but it seemed less problematic to just leave it as-is, and it was easy to add the TPM version

fixes #120 